### PR TITLE
Recorders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- Recording input/output streams.
+
 ## [0.5.0] - 2021-01-18
 ### Added
 - Error indication

--- a/streamlit_webrtc/__init__.py
+++ b/streamlit_webrtc/__init__.py
@@ -77,7 +77,12 @@ class ClientSettings(TypedDict):
     media_stream_constraints: Optional[MediaStreamConstraints]
 
 
+class WebRtcWorkerState(NamedTuple):
+    playing: bool
+
+
 class WebRtcWorkerContext(NamedTuple):
+    state: WebRtcWorkerState
     video_transformer: Optional[VideoTransformerBase]
     video_receiver: Optional[VideoReceiver]
 
@@ -110,6 +115,7 @@ def webrtc_streamer(
         settings=client_settings,
     )
 
+    playing = False
     if component_value:
         playing = component_value.get("playing", False)
         sdp_offer = component_value.get("sdpOffer")
@@ -133,6 +139,7 @@ def webrtc_streamer(
                 st.experimental_rerun()  # Rerun to send the SDP answer to frontend
 
     ctx = WebRtcWorkerContext(
+        state=WebRtcWorkerState(playing=playing),
         video_transformer=webrtc_worker.video_transformer if webrtc_worker else None,
         video_receiver=webrtc_worker.video_receiver if webrtc_worker else None,
     )

--- a/streamlit_webrtc/__init__.py
+++ b/streamlit_webrtc/__init__.py
@@ -25,6 +25,7 @@ from . import SessionState
 from .config import MediaStreamConstraints, RTCConfiguration
 from .webrtc import (
     MediaPlayerFactory,
+    MediaRecorderFactory,
     VideoReceiver,
     VideoTransformerBase,
     WebRtcMode,
@@ -86,6 +87,8 @@ def webrtc_streamer(
     mode: WebRtcMode = WebRtcMode.SENDRECV,
     client_settings: Optional[ClientSettings] = None,
     player_factory: Optional[MediaPlayerFactory] = None,
+    in_recorder_factory: Optional[MediaRecorderFactory] = None,
+    out_recorder_factory: Optional[MediaRecorderFactory] = None,
     video_transformer_factory: Optional[Callable[[], VideoTransformerBase]] = None,
     async_transform: bool = True,
 ) -> WebRtcWorkerContext:
@@ -120,6 +123,8 @@ def webrtc_streamer(
                 webrtc_worker = WebRtcWorker(
                     mode=mode,
                     player_factory=player_factory,
+                    in_recorder_factory=in_recorder_factory,
+                    out_recorder_factory=out_recorder_factory,
                     video_transformer_factory=video_transformer_factory,
                     async_transform=async_transform,
                 )

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -112,8 +112,10 @@ async def _process_offer(
 
                 pc.addTrack(output_track)
                 if out_recorder:
+                    logger.info("Track %s is added to out_recorder", output_track.kind)
                     out_recorder.addTrack(output_track)
                 if in_recorder:
+                    logger.info("Track %s is added to in_recorder", input_track.kind)
                     in_recorder.addTrack(input_track)
 
                 @input_track.on("ended")
@@ -141,6 +143,7 @@ async def _process_offer(
                         video_receiver.addTrack(input_track)
 
                 if in_recorder:
+                    logger.info("Track %s is added to in_recorder", input_track.kind)
                     in_recorder.addTrack(input_track)
 
                 @input_track.on("ended")

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -9,7 +9,7 @@ from asyncio.events import AbstractEventLoop
 from typing import Callable, Optional, Union
 
 from aiortc import RTCPeerConnection, RTCSessionDescription
-from aiortc.contrib.media import MediaPlayer
+from aiortc.contrib.media import MediaPlayer, MediaRecorder
 
 from .receive import VideoReceiver
 from .transform import (
@@ -26,6 +26,7 @@ logger.addHandler(logging.NullHandler())
 VideoTransformFn = Callable
 
 MediaPlayerFactory = Callable[[], MediaPlayer]
+MediaRecorderFactory = Callable[[], MediaRecorder]
 VideoTransformerFactory = Callable[[], VideoTransformerBase]
 
 
@@ -40,6 +41,8 @@ async def _process_offer(
     pc: RTCPeerConnection,
     offer: RTCSessionDescription,
     player_factory: Optional[MediaPlayerFactory],
+    in_recorder_factory: Optional[MediaRecorderFactory],
+    out_recorder_factory: Optional[MediaRecorderFactory],
     video_transformer: Optional[VideoTransformerBase],
     video_receiver: Optional[VideoReceiver],
     async_transform: bool,
@@ -50,6 +53,14 @@ async def _process_offer(
         if player_factory:
             player = player_factory()
 
+        in_recorder = None
+        if in_recorder_factory:
+            in_recorder = in_recorder_factory()
+
+        out_recorder = None
+        if out_recorder_factory:
+            out_recorder = out_recorder_factory()
+
         @pc.on("iceconnectionstatechange")
         async def on_iceconnectionstatechange():
             logger.info("ICE connection state is %s", pc.iceConnectionState)
@@ -59,16 +70,22 @@ async def _process_offer(
         if mode == WebRtcMode.SENDRECV:
 
             @pc.on("track")
-            def on_track(track):
-                logger.info("Track %s received", track.kind)
+            def on_track(input_track):
+                logger.info("Track %s received", input_track.kind)
 
-                if track.kind == "audio":
+                output_track = None
+
+                if input_track.kind == "audio":
                     if player and player.audio:
-                        pc.addTrack(player.audio)
-                elif track.kind == "video":
+                        logger.info("Add player to audio track")
+                        output_track = player.audio
+                    else:
+                        # Transforming audio is not supported yet.
+                        output_track = input_track  # passthrough
+                elif input_track.kind == "video":
                     if player and player.video:
                         logger.info("Add player to video track")
-                        pc.addTrack(player.video)
+                        output_track = player.video
                     elif video_transformer:
                         VideoTrack = (
                             AsyncVideoTransformTrack
@@ -78,49 +95,88 @@ async def _process_offer(
                         logger.info(
                             "Add a input video track %s to "
                             "another track with video_transformer %s",
-                            track,
+                            input_track,
                             VideoTrack,
                         )
                         local_video = VideoTrack(
-                            track=track, video_transformer=video_transformer
+                            track=input_track, video_transformer=video_transformer
                         )
                         logger.info("Add the video track with transfomer to %s", pc)
-                        pc.addTrack(local_video)
+                        output_track = local_video
+
+                if not output_track:
+                    raise Exception(
+                        "Neither a player nor a transformer is created. "
+                        "Either factory must be set."
+                    )
+
+                pc.addTrack(output_track)
+                if out_recorder:
+                    out_recorder.addTrack(output_track)
+                if in_recorder:
+                    in_recorder.addTrack(input_track)
+
+                @input_track.on("ended")
+                async def on_ended():
+                    logger.info("Track %s ended", input_track.kind)
+                    if in_recorder:
+                        await in_recorder.stop()
+                    if out_recorder:
+                        await out_recorder.stop()
 
         elif mode == WebRtcMode.SENDONLY:
 
             @pc.on("track")
-            def on_track(track):
-                logger.info("Track %s received", track.kind)
+            def on_track(input_track):
+                logger.info("Track %s received", input_track.kind)
 
-                if track.kind == "audio":
+                if input_track.kind == "audio":
                     # Not supported yet
                     pass
-                elif track.kind == "video":
+                elif input_track.kind == "video":
                     if video_receiver:
                         logger.info(
-                            "Add a track %s to receiver %s", track, video_receiver
+                            "Add a track %s to receiver %s", input_track, video_receiver
                         )
-                        video_receiver.addTrack(track)
+                        video_receiver.addTrack(input_track)
 
-                @track.on("ended")
+                if in_recorder:
+                    in_recorder.addTrack(input_track)
+
+                @input_track.on("ended")
                 async def on_ended():
-                    logger.info("Track %s ended", track.kind)
+                    logger.info("Track %s ended", input_track.kind)
                     if video_receiver:
                         video_receiver.stop()
+                    if in_recorder:
+                        await in_recorder.stop()
 
         await pc.setRemoteDescription(offer)
         if mode == WebRtcMode.RECVONLY:
             for t in pc.getTransceivers():
+                output_track = None
                 if t.kind == "audio":
                     if player and player.audio:
-                        pc.addTrack(player.audio)
+                        output_track = player.audio
+                        # pc.addTrack(player.audio)
                 elif t.kind == "video":
                     if player and player.video:
-                        pc.addTrack(player.video)
+                        # pc.addTrack(player.video)
+                        output_track = player.video
+
+                if output_track:
+                    pc.addTrack(output_track)
+                    # NOTE: Recording is not supported in this mode
+                    # because connecting player to recorder does not work somehow;
+                    # it generates unplayable movie files.
 
         if video_receiver and video_receiver.hasTrack():
             video_receiver.start()
+
+        if in_recorder:
+            await in_recorder.start()
+        if out_recorder:
+            await out_recorder.start()
 
         answer = await pc.createAnswer()
         await pc.setLocalDescription(answer)
@@ -151,6 +207,8 @@ class WebRtcWorker:
         self,
         mode: WebRtcMode,
         player_factory: Optional[MediaPlayerFactory] = None,
+        in_recorder_factory: Optional[MediaRecorderFactory] = None,
+        out_recorder_factory: Optional[MediaRecorderFactory] = None,
         video_transformer_factory: Optional[VideoTransformerFactory] = None,
         async_transform: bool = True,
     ) -> None:
@@ -162,6 +220,8 @@ class WebRtcWorker:
 
         self.mode = mode
         self.player_factory = player_factory
+        self.in_recorder_factory = in_recorder_factory
+        self.out_recorder_factory = out_recorder_factory
         self.video_transformer_factory = video_transformer_factory
         self.async_transform = async_transform
 
@@ -172,6 +232,8 @@ class WebRtcWorker:
         self,
         sdp: str,
         type_: str,
+        in_recorder_factory: Optional[MediaRecorderFactory],
+        out_recorder_factory: Optional[MediaRecorderFactory],
         player_factory: Optional[MediaPlayerFactory],
         video_transformer_factory: Optional[VideoTransformerFactory],
         video_receiver: Optional[VideoReceiver],
@@ -182,6 +244,8 @@ class WebRtcWorker:
                 sdp=sdp,
                 type_=type_,
                 player_factory=player_factory,
+                in_recorder_factory=in_recorder_factory,
+                out_recorder_factory=out_recorder_factory,
                 video_transformer_factory=video_transformer_factory,
                 video_receiver=video_receiver,
                 async_transform=async_transform,
@@ -202,6 +266,8 @@ class WebRtcWorker:
         sdp: str,
         type_: str,
         player_factory: Optional[MediaPlayerFactory],
+        in_recorder_factory: Optional[MediaRecorderFactory],
+        out_recorder_factory: Optional[MediaRecorderFactory],
         video_transformer_factory: Optional[Callable[[], VideoTransformerBase]],
         video_receiver: Optional[VideoReceiver],
         async_transform: bool,
@@ -240,7 +306,9 @@ class WebRtcWorker:
                 self.mode,
                 self.pc,
                 offer,
-                player_factory,
+                player_factory=player_factory,
+                in_recorder_factory=in_recorder_factory,
+                out_recorder_factory=out_recorder_factory,
                 video_transformer=video_transformer,
                 video_receiver=video_receiver,
                 async_transform=async_transform,
@@ -267,6 +335,8 @@ class WebRtcWorker:
                 "sdp": sdp,
                 "type_": type_,
                 "player_factory": self.player_factory,
+                "in_recorder_factory": self.in_recorder_factory,
+                "out_recorder_factory": self.out_recorder_factory,
                 "video_transformer_factory": self.video_transformer_factory,
                 "video_receiver": self._video_receiver,
                 "async_transform": self.async_transform,


### PR DESCRIPTION
Recorders can be used like below, but currently there is no efficient way to download the recorded files in Streamlit 😿 
```python
    in_record_to = HERE / "data/records" / "in.mp4"
    in_recorder_factory = None
    if st.checkbox("Record a video stream coming into the server"):

        def in_recorder_factory():
            in_record_to.parent.mkdir(parents=True, exist_ok=True)
            return MediaRecorder(str(in_record_to))

    out_record_to = HERE / "data/records" / "out.mp4"
    out_recorder_factory = None
    if st.checkbox("Record a video stream going out from the server"):

        def out_recorder_factory():
            out_record_to.parent.mkdir(parents=True, exist_ok=True)
            return MediaRecorder(str(out_record_to))

    webrtc_ctx = webrtc_streamer(
        key="object-detection",
        mode=WebRtcMode.SENDRECV,
        client_settings=WEBRTC_CLIENT_SETTINGS,
        video_transformer_factory=NNVideoTransformer,
        in_recorder_factory=in_recorder_factory,
        out_recorder_factory=out_recorder_factory,
        async_transform=True,
    )

    confidence_threshold = st.slider(
        "Confidence threshold", 0.0, 1.0, DEFAULT_CONFIDENCE_THRESHOLD, 0.05
    )
    if webrtc_ctx.video_transformer:
        webrtc_ctx.video_transformer.confidence_threshold = confidence_threshold

    if not webrtc_ctx.state.playing:
        if in_record_to.exists():
            st.write(
                f"Recoded video available from the received stream: {in_record_to}"
            )

        if out_record_to.exists():
            st.write(
                f"Recoded video available from the transmitted stream: {out_record_to}"
            )
```