### PR TITLE
Fix to use relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Fix
+- Fix to use `MediaRelay`, #263.
+
 ## [0.22.1] - 2021-06-20
 ### Fix
 - Fix to unset the worker when the state is not playing, #255.

--- a/streamlit_webrtc/relay.py
+++ b/streamlit_webrtc/relay.py
@@ -1,0 +1,25 @@
+import asyncio
+from typing import Dict, Union
+
+from aiortc.contrib.media import MediaRelay
+
+_relays: Dict[asyncio.AbstractEventLoop, MediaRelay] = dict()
+
+
+def get_relay(loop: asyncio.AbstractEventLoop) -> MediaRelay:
+    global _relays
+
+    if loop not in _relays:
+        cur_ev_loop: Union[asyncio.AbstractEventLoop, None]
+        try:
+            cur_ev_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            cur_ev_loop = None
+        asyncio.set_event_loop(loop)
+
+        relay = MediaRelay()
+        _relays[loop] = relay
+
+        asyncio.set_event_loop(cur_ev_loop)
+
+    return _relays[loop]


### PR DESCRIPTION
`MediaRelay` should be used when one track is connected to multiple consumers.
See the official example: https://github.com/aiortc/aiortc/blob/a270cd887fba4ce9ccb680d267d7d0a897de3d75/examples/server/server.py#L145-L151