### PR TITLE
Remove dummy assignments on await-s as they are no longer necessary after streamlit 1.11

### DIFF
--- a/pages/delayed_echo.py
+++ b/pages/delayed_echo.py
@@ -20,14 +20,14 @@ async def queued_video_frames_callback(
     # the Streamlit magic's target, which leads implicit calls of `st.write`.
     # To prevent it, fix it as `_ = await ...`, a statement.
     # See https://discuss.streamlit.io/t/issue-with-asyncio-run-in-streamlit/7745/15
-    _ = await asyncio.sleep(delay)
+    await asyncio.sleep(delay)
     return frames
 
 
 async def queued_audio_frames_callback(
     frames: List[av.AudioFrame],
 ) -> List[av.AudioFrame]:
-    _ = await asyncio.sleep(delay)
+    await asyncio.sleep(delay)
     return frames
 
 


### PR DESCRIPTION
Instead of #1000