### PR TITLE
Specify cryptography = "<39" to avoid the drawback introduced with its 39.0.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fix
+
+- Specify the version of `cryptography` to avoid the bug reported at [#1164](https://github.com/whitphx/streamlit-webrtc/issues/1164), #1167.
+
 ## [0.44.0] - 2022-10-17
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ streamlit = ">=0.84.1"
 aiortc = "^1.1.2"
 typing_extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
 packaging = ">=20.0"
+cryptography = "<39"  # See https://github.com/whitphx/streamlit-webrtc/issues/1164. TODO: Specify more detailed version after this problem is solved.
 
 [tool.poetry.group.dev.dependencies]
 black = "^21.12b0"


### PR DESCRIPTION
Resolves #1164