### PR TITLE
Remove @st.cache_data on get_ice_servers() because the ICE servers data may change

### DIFF
--- a/sample_utils/turn.py
+++ b/sample_utils/turn.py
@@ -8,7 +8,6 @@ from twilio.rest import Client
 logger = logging.getLogger(__name__)
 
 
-@st.cache_data  # type: ignore
 def get_ice_servers():
     """Use Twilio's TURN server because Streamlit Community Cloud has changed
     its infrastructure and WebRTC connection cannot be established without TURN server now.  # noqa: E501


### PR DESCRIPTION
This might be a solution for https://discuss.streamlit.io/t/webrtc-component-examples-are-not-working-in-streamlit-anymore/50557