### PR TITLE
Set the TURN server configs on frontend

### DIFF
--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -38,7 +38,6 @@ from .config import (
     AudioHTMLAttributes,
     MediaStreamConstraints,
     RTCConfiguration,
-    RTCIceServer,
     Translations,
     VideoHTMLAttributes,
     compile_ice_servers,
@@ -606,9 +605,7 @@ def webrtc_streamer(
             LOGGER.info(
                 "rtc_configuration.iceServers is not set. Try to set it automatically."
             )
-            ice_servers = [
-                RTCIceServer(urls="stun:stun.l.google.com:19302"),
-            ]
+            ice_servers = get_available_ice_servers()
             aiortc_rtc_configuration.iceServers = compile_ice_servers(ice_servers)
 
         webrtc_worker = WebRtcWorker(

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -40,7 +40,6 @@ from .config import (
     RTCConfiguration,
     Translations,
     VideoHTMLAttributes,
-    compile_ice_servers,
     compile_rtc_configuration,
 )
 from .credentials import (
@@ -601,13 +600,6 @@ def webrtc_streamer(
             if server_rtc_configuration and isinstance(server_rtc_configuration, dict)
             else AiortcRTCConfiguration()
         )
-
-        if aiortc_rtc_configuration.iceServers is None:
-            LOGGER.info(
-                "rtc_configuration.iceServers is not set. Try to set it automatically."
-            )
-            ice_servers = get_available_ice_servers()
-            aiortc_rtc_configuration.iceServers = compile_ice_servers(ice_servers)
 
         webrtc_worker = WebRtcWorker(
             mode=mode,

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -40,6 +40,7 @@ from .config import (
     RTCConfiguration,
     Translations,
     VideoHTMLAttributes,
+    compile_ice_servers,
     compile_rtc_configuration,
 )
 from .credentials import (
@@ -600,6 +601,13 @@ def webrtc_streamer(
             if server_rtc_configuration and isinstance(server_rtc_configuration, dict)
             else AiortcRTCConfiguration()
         )
+
+        if aiortc_rtc_configuration.iceServers is None:
+            LOGGER.info(
+                "rtc_configuration.iceServers is not set. Try to set it automatically."
+            )
+            ice_servers = get_available_ice_servers()
+            aiortc_rtc_configuration.iceServers = compile_ice_servers(ice_servers)
 
         webrtc_worker = WebRtcWorker(
             mode=mode,

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -40,7 +40,6 @@ from .config import (
     RTCConfiguration,
     Translations,
     VideoHTMLAttributes,
-    compile_ice_servers,
     compile_rtc_configuration,
 )
 from .credentials import (

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -38,8 +38,10 @@ from .config import (
     AudioHTMLAttributes,
     MediaStreamConstraints,
     RTCConfiguration,
+    RTCIceServer,
     Translations,
     VideoHTMLAttributes,
+    compile_ice_servers,
     compile_rtc_configuration,
 )
 from .credentials import (
@@ -600,6 +602,14 @@ def webrtc_streamer(
             if server_rtc_configuration and isinstance(server_rtc_configuration, dict)
             else AiortcRTCConfiguration()
         )
+        if aiortc_rtc_configuration.iceServers is None:
+            LOGGER.info(
+                "rtc_configuration.iceServers is not set. Try to set it automatically."
+            )
+            ice_servers = [
+                RTCIceServer(urls="stun:stun.l.google.com:19302"),
+            ]
+            aiortc_rtc_configuration.iceServers = compile_ice_servers(ice_servers)
 
         webrtc_worker = WebRtcWorker(
             mode=mode,

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -475,11 +475,9 @@ def webrtc_streamer(
         context._frontend_rtc_configuration = {}
     if context._frontend_rtc_configuration.get("iceServers") is None:
         LOGGER.info(
-            "No iceServers found in the rtc_configuration for the frontend. Set the default value to use Google STUN server."
+            "frontend_rtc_configuration.iceServers is not set. Try to set it automatically."
         )
-        context._frontend_rtc_configuration["iceServers"] = [
-            {"urls": "stun:stun.l.google.com:19302"}
-        ]
+        context._frontend_rtc_configuration["iceServers"] = get_available_ice_servers()
 
     webrtc_worker = context._get_worker()
 
@@ -603,13 +601,6 @@ def webrtc_streamer(
             if server_rtc_configuration and isinstance(server_rtc_configuration, dict)
             else AiortcRTCConfiguration()
         )
-
-        if aiortc_rtc_configuration.iceServers is None:
-            LOGGER.info(
-                "rtc_configuration.iceServers is not set. Try to set it automatically."
-            )
-            ice_servers = get_available_ice_servers()
-            aiortc_rtc_configuration.iceServers = compile_ice_servers(ice_servers)
 
         webrtc_worker = WebRtcWorker(
             mode=mode,

--- a/streamlit_webrtc/credentials.py
+++ b/streamlit_webrtc/credentials.py
@@ -86,8 +86,12 @@ def get_twilio_ice_servers(
 def get_available_ice_servers() -> List[RTCIceServer]:
     try:
         LOGGER.info("Try to use TURN server from Hugging Face.")
-        ice_servers = get_hf_ice_servers()
+        hf_turn_servers = get_hf_ice_servers()
         LOGGER.info("Successfully got TURN credentials from Hugging Face.")
+        LOGGER.info("Using TURN server from Hugging Face and STUN server from Google.")
+        ice_servers = hf_turn_servers + [
+            RTCIceServer(urls="stun:stun.l.google.com:19302"),
+        ]
         return ice_servers
     except Exception as e:
         LOGGER.info("Failed to get TURN credentials from Hugging Face: %s", e)

--- a/streamlit_webrtc/credentials.py
+++ b/streamlit_webrtc/credentials.py
@@ -97,9 +97,9 @@ def get_available_ice_servers() -> List[RTCIceServer]:
         LOGGER.info("Failed to get TURN credentials from Hugging Face: %s", e)
 
     try:
-        LOGGER.info("Try to use TURN server from Twilio.")
+        LOGGER.info("Try to use STUN/TURN server from Twilio.")
         ice_servers = get_twilio_ice_servers()
-        LOGGER.info("Successfully got TURN credentials from Twilio.")
+        LOGGER.info("Successfully got STUN/TURN credentials from Twilio.")
         return ice_servers
     except Exception as e:
         LOGGER.info("Failed to get TURN credentials from Twilio: %s", e)


### PR DESCRIPTION
Because **both peers need to have the ICE configs** for them.
Refs:
* https://stackoverflow.com/questions/61456009/do-both-endpoints-in-webrtc-need-stun-turn-config-credentials
* https://webrtcforthecurious.com/docs/webrtc-for-the-curious.pdf
