### PR TITLE
Fix SessionShutdownObserver not to call the callback when requested to stop()

### DIFF
--- a/streamlit_webrtc/shutdown.py
+++ b/streamlit_webrtc/shutdown.py
@@ -40,7 +40,7 @@ class SessionShutdownObserver:
     ):
         # Use polling because event-based methods are not available
         # to observe the session lifecycle.
-        while not self._polling_thread_stop_event.wait(1.0):
+        while True:
             app_session = app_session_ref()
             if not app_session:
                 logger.debug("AppSession has removed.")
@@ -51,6 +51,11 @@ class SessionShutdownObserver:
                     app_session.id,
                 )
                 break
+            if self._polling_thread_stop_event.wait(1.0):
+                logger.debug(
+                    "The polling thread should be stopped. Exit the polling loop and return."
+                )
+                return
 
         # Ensure the flag is set
         self._polling_thread_stop_event.set()

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -672,6 +672,8 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
         self._relayed_source_video_track = None
 
     def stop(self, timeout: Union[float, None] = 1.0):
+        logger.debug("Stopping the WebRTC worker")
+
         self._unset_processors()
         if self._process_offer_thread:
             self._process_offer_thread.join(timeout=timeout)


### PR DESCRIPTION
Resolves #1979

Due to this bug, `WebRtcWorker.stop()` is called twice.
