### PR TITLE
Fix WebRtcWorker to instantiate asyncio.Event with a loop

### DIFF
--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -28,7 +28,7 @@ from aiortc.sdp import candidate_from_sdp
 
 from streamlit_webrtc.shutdown import SessionShutdownObserver
 
-from .eventloop import get_global_event_loop
+from .eventloop import get_global_event_loop, loop_context
 from .models import (
     AudioFrameCallback,
     AudioProcessorBase,
@@ -383,8 +383,10 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
     ) -> None:
         self._process_offer_thread: Union[threading.Thread, None] = None
         self.pc = RTCPeerConnection(rtc_configuration)
-        self._remote_description_set: asyncio.Event = asyncio.Event()
         self._answer_queue: queue.Queue = queue.Queue()
+
+        with loop_context(get_global_event_loop()):
+            self._remote_description_set = asyncio.Event()
 
         self.mode = mode
         self.source_video_track = source_video_track


### PR DESCRIPTION
Fix an error:
```
RuntimeError: There is no current event loop in thread 
'ScriptRunner.scriptThread'.
────────────────────── Traceback (most recent call last) ───────────────────────
  /home/adminuser/venv/lib/python3.9/site-packages/streamlit/runtime/scriptrun  
  ner/exec_code.py:121 in exec_func_with_error_handling                         
                                                                                
  /home/adminuser/venv/lib/python3.9/site-packages/streamlit/runtime/scriptrun  
  ner/script_runner.py:640 in code_to_exec                                      
                                                                                
  /mount/src/streamlit-webrtc-example/app.py:140 in <module>                    
                                                                                
    137 │   return av.VideoFrame.from_ndarray(image, format="bgr24")            
    138                                                                         
    139                                                                         
  ❱ 140 webrtc_ctx = webrtc_streamer(                                           
    141 │   key="object-detection",                                             
    142 │   mode=WebRtcMode.SENDRECV,                                           
    143 │   video_frame_callback=video_frame_callback,                          
                                                                                
  /home/adminuser/venv/lib/python3.9/site-packages/streamlit_webrtc/component.  
  py:616 in webrtc_streamer                                                     
                                                                                
  /home/adminuser/venv/lib/python3.9/site-packages/streamlit_webrtc/webrtc.py:  
  386 in __init__                                                               
                                                                                
  /usr/local/lib/python3.9/asyncio/locks.py:177 in __init__                     
                                                                                
    174 │   │   self._waiters = collections.deque()                             
    175 │   │   self._value = False                                             
    176 │   │   if loop is None:                                                
  ❱ 177 │   │   │   self._loop = events.get_event_loop()                        
    178 │   │   else:                                                           
    179 │   │   │   self._loop = loop                                           
    180 │   │   │   warnings.warn("The loop argument is deprecated since Pytho  
                                                                                
  /usr/local/lib/python3.9/asyncio/events.py:642 in get_event_loop              
                                                                                
    639 │   │   │   self.set_event_loop(self.new_event_loop())                  
    640 │   │                                                                   
    641 │   │   if self._local._loop is None:                                   
  ❱ 642 │   │   │   raise RuntimeError('There is no current event loop in thre  
    643 │   │   │   │   │   │   │      % threading.current_thread().name)       
    644 │   │                                                                   
    645 │   │   return self._local._loop                                        
```