### PR TITLE
Register the stop callback in AsyncMediaProcessTrack.__init__() but n…

### DIFF
--- a/streamlit_webrtc/process.py
+++ b/streamlit_webrtc/process.py
@@ -82,6 +82,12 @@ class AsyncMediaProcessTrack(MediaStreamTrack, Generic[ProcessorT, FrameT]):
 
         self._thread: Optional[threading.Thread] = None
 
+        def on_input_track_ended():
+            logger.debug("Input track %s ended. Stop self %s", self.track, self)
+            self.stop()
+
+        self.track.on("ended", on_input_track_ended)
+
     def _start(self) -> None:
         if self._thread:
             return
@@ -96,12 +102,6 @@ class AsyncMediaProcessTrack(MediaStreamTrack, Generic[ProcessorT, FrameT]):
             daemon=True,
         )
         self._thread.start()
-
-        def on_input_track_ended():
-            logger.debug("Input track %s ended. Stop self %s", self.track, self)
-            self.stop()
-
-        self.track.on("ended", on_input_track_ended)
 
     def _run_worker_thread(self):
         try:


### PR DESCRIPTION
…ot in ._start()