### PR TITLE
Changed code from asyncio.get_event_loop() to get_running_loop

### DIFF
--- a/streamlit_webrtc/eventloop.py
+++ b/streamlit_webrtc/eventloop.py
@@ -38,9 +38,15 @@ def get_global_event_loop() -> asyncio.AbstractEventLoop:
 def loop_context(loop: asyncio.AbstractEventLoop):
     cur_ev_loop: Union[asyncio.AbstractEventLoop, None]
     try:
-        cur_ev_loop = asyncio.get_event_loop()
+        # Try to get the running loop first (if we're in async context)
+        cur_ev_loop = asyncio.get_running_loop()
     except RuntimeError:
-        cur_ev_loop = None
+        # No running loop, try to get the current loop from policy
+        try:
+            cur_ev_loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            cur_ev_loop = None
+    
     asyncio.set_event_loop(loop)
 
     yield

--- a/streamlit_webrtc/receive.py
+++ b/streamlit_webrtc/receive.py
@@ -40,7 +40,16 @@ class MediaReceiver(Generic[FrameT]):
     def start(self):
         if self._task is not None:
             raise Exception(f"{self} has already a started task {self._task}")
-        loop = asyncio.get_event_loop()
+        
+        # Try to get the running loop first (if we're in async context)
+        # Otherwise get the event loop for the current thread
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop, so we need to get/create one
+            # Policy manages per-thread loops: gets existing or creates new one
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+        
         self._task = loop.create_task(coro=self._run_track(self._track))
 
     def stop(self):

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -761,7 +761,10 @@ def _test():
     # Mock functions that depend on Streamlit global server object
     global get_global_relay, get_global_event_loop
 
-    loop = asyncio.get_event_loop()
+    # Use new_event_loop() instead of deprecated get_event_loop()
+    # since this test function runs outside of async context
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     def get_global_event_loop_mock():
         return loop


### PR DESCRIPTION
Fix deprecated asyncio.get_event_loop() usage for Python 3.12+ compatibility 
#2190 

Replaced deprecated asyncio.get_event_loop() calls in 3 locations:
1. webrtc.py: Used new_event_loop() + set_event_loop() for test function
2. receive.py: Added try/except pattern with get_running_loop() fallback to policy
3. eventloop.py: Enhanced context manager with proper loop detection

Changes ensure future compatibility by using `get_running_loop()` for async contexts and `get_event_loop_policy().get_event_loop()`  for non-async contexts. All existing functionality tested and verified working correctly with WebRTC features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability in async scenarios by more robustly detecting and restoring the event loop, reducing runtime errors when no loop is running.
  - Prevents lingering event loop side effects after operations, improving stability across sessions.

- Refactor
  - Replaced deprecated event loop APIs with modern patterns for better compatibility with newer Python versions.
  - Ensured explicit loop management in internal tests to provide more consistent and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->