### PR TITLE
Move the deploy-preview-wheel job to the post-build workflow that is triggered in the main branch context so that it works on PRs by external contributors

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,6 +15,58 @@ on:
 permissions: {}
 
 jobs:
+  set-build-info:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.build-info.outputs.branch }}
+      tag: ${{ steps.build-info.outputs.tag }}
+      trigger-sha: ${{ steps.build-info.outputs.trigger-sha }}
+      head-sha: ${{ steps.build-info.outputs.head-sha }}
+      pr-number: ${{ steps.build-info.outputs.pr-number }}
+    steps:
+      - name: Save build info (pull_request)
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "${{ github.event.pull_request.head.ref }}" > branch
+          echo "" > tag
+          echo "${{ github.event.pull_request.head.sha }}" > head-sha
+          echo "${{ github.sha }}" > trigger-sha
+          echo "${{ github.event.pull_request.number }}" > pr-number
+      - name: Save build info (push, branch)
+        if: github.event_name == 'push' && github.ref_type == 'branch'
+        run: |
+          echo "${{ github.ref_name }}" > branch
+          echo "" > tag
+          echo "${{ github.sha }}" > head-sha
+          echo "${{ github.sha }}" > trigger-sha
+          echo "" > pr-number
+      - name: Save build info (push, tag)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: |
+          echo "" > branch
+          echo "${{ github.ref_name }}" > tag
+          echo "${{ github.sha }}" > head-sha
+          echo "${{ github.sha }}" > trigger-sha
+          echo "" > pr-number
+      - name: Output build info
+        id: build-info
+        run: |
+          echo "branch=$(cat branch)" >> $GITHUB_OUTPUT
+          echo "tag=$(cat tag)" >> $GITHUB_OUTPUT
+          echo "trigger-sha=$(cat trigger-sha)" >> $GITHUB_OUTPUT
+          echo "head-sha=$(cat head-sha)" >> $GITHUB_OUTPUT
+          echo "pr-number=$(cat pr-number)" >> $GITHUB_OUTPUT
+      - name: Upload build info
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: build-info
+          path: |
+            branch
+            tag
+            head-sha
+            trigger-sha
+            pr-number
+
   test-python:
     runs-on: ubuntu-latest
     strategy:
@@ -176,65 +228,6 @@ jobs:
       with:
         name: streamlit-webrtc-${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha  }}
         path: dist
-
-  deploy-preview-wheel:
-    runs-on: ubuntu-latest
-    needs: [build]
-    if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-    name: Deploy wheel file to Cloudflare Pages
-    outputs:
-      url: ${{ steps.deploy.outputs.deployment-url }}
-    steps:
-      - run: mkdir -p ${{ runner.temp }}/artifacts/
-
-      - name: Download all the dists
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          name: streamlit-webrtc-${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha  }}
-          path: ${{ runner.temp }}/artifacts/streamlit-webrtc
-
-      - name: Deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
-        id: deploy
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: >-
-            pages deploy ${{ runner.temp }}/artifacts/streamlit-webrtc --project-name=streamlit-webrtc-preview --branch=${{ github.head_ref || github.ref_name }} --commit-hash=${{ github.sha }}
-
-      - name: Comment on the PR to inform the deployment file URLs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
-
-            // Get all files in the artifacts directory
-            const artifactsDir = '${{ runner.temp }}/artifacts/streamlit-webrtc';
-            const allFiles = fs.readdirSync(artifactsDir);
-            // Filter to include only wheel (.whl) and source distribution (.tar.gz) files
-            const files = allFiles.filter(file => file.endsWith('.whl') || file.endsWith('.tar.gz'));
-
-            // Create message with links to each file
-            let fileLinks = files.map(file => {
-              const installCommand = `pip install ${deploymentUrl}/${file}`;
-              return `- [${file}](${deploymentUrl}/${file})\n  \`\`\`bash\n  ${installCommand}\n  \`\`\``;
-            }).join('\n');
-
-            const message = `📦 Wheel files have been deployed to Cloudflare Pages:
-
-            ${fileLinks}`;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: message
-            });
 
   publish-to-pypi:
     name: Publish Python 🐍 distribution 📦 to PyPI

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,4 +1,4 @@
-name: Test, Build, and Publish
+name: Test and Build
 
 on:
   push:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now consistently captures and uploads build metadata (branch, tag, commit SHAs, PR number) as outputs and artifacts for PR, branch, and tag runs.
  * Removed the preview deployment job; PRs will no longer receive preview deployment links or comments.
  * Publishing to PyPI and its behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->