### PR TITLE
ci: Add Aikido Safe Chain to guard pnpm installs

### DIFF
--- a/.github/actions/install-safe-chain/action.yml
+++ b/.github/actions/install-safe-chain/action.yml
@@ -1,0 +1,9 @@
+name: Install Aikido Safe Chain
+description: Install Aikido Safe Chain to guard npm/pnpm package installs against malicious packages.
+
+runs:
+  using: composite
+  steps:
+    - name: Install Aikido Safe Chain
+      shell: bash
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -175,6 +175,8 @@ jobs:
         node-version-file: .nvmrc
         cache-dependency-path: streamlit_webrtc/frontend/pnpm-lock.yaml
 
+    - uses: ./.github/actions/install-safe-chain
+
     - name: Install dependencies
       run: pnpm install
 
@@ -219,6 +221,8 @@ jobs:
         cache: 'pnpm'
         node-version-file: .nvmrc
         cache-dependency-path: streamlit_webrtc/frontend/pnpm-lock.yaml
+
+    - uses: ./.github/actions/install-safe-chain
 
     - name: Install dependencies
       run: pnpm install


### PR DESCRIPTION
Extracted into a reusable composite action and invoked before `pnpm install` in both the test-frontend and build jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to add a pre-install step that installs "Aikido Safe Chain" before dependency installation for test and build jobs.
  * Ensures the safe-chain installation runs automatically in CI to support consistent build/test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->