### PR TITLE
Update prettier from 3.6.2 to 3.8.3

### DIFF
--- a/streamlit_webrtc/frontend/package.json
+++ b/streamlit_webrtc/frontend/package.json
@@ -43,7 +43,7 @@
     "globals": "^17.5.0",
     "jsdom": "^29.0.2",
     "npm-run-all2": "^8.0.4",
-    "prettier": "^3.6.2",
+    "prettier": "^3.8.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",
     "vite": "^8.0.9",

--- a/streamlit_webrtc/frontend/pnpm-lock.yaml
+++ b/streamlit_webrtc/frontend/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
+        specifier: ^3.8.3
+        version: 3.8.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3200,8 +3200,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.6.2:
-    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7567,7 +7567,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.6.2: {}
+  prettier@3.8.3: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -50,16 +50,14 @@ interface DeviceSelectionState {
 interface DeviceSelectionActionBase {
   type: string;
 }
-interface DeviceSelectionSetUnavailableAction
-  extends DeviceSelectionActionBase {
+interface DeviceSelectionSetUnavailableAction extends DeviceSelectionActionBase {
   type: "SET_UNAVAILABLE";
 }
 interface DeviceSelectionUpdateDevicesAction extends DeviceSelectionActionBase {
   type: "UPDATE_DEVICES";
   devices: MediaDeviceInfo[];
 }
-interface DeviceSelectionUpdateSelectedDeviceIdAction
-  extends DeviceSelectionActionBase {
+interface DeviceSelectionUpdateSelectedDeviceIdAction extends DeviceSelectionActionBase {
   type: "UPDATE_SELECTED_DEVICE_ID";
   payload: {
     selectedVideoInputDeviceId?: MediaDeviceInfo["deviceId"] | undefined;


### PR DESCRIPTION
Reformats DeviceSelect.tsx to match 3.8.x's revised handling of single-line `interface X extends Y` declarations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to latest versions

* **Style**
  * Code formatting improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->