### PR TITLE
fix: bump scriv-release to v0.2.3

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: whitphx/scriv-release/.github/workflows/reusable.yml@30455fdde15a17cae1ba33ce2f074e56532da755 # v0.2.1
+    uses: whitphx/scriv-release/.github/workflows/reusable.yml@e0903b1fd894bc1a25c3eb6b02e5c3581d7b8a6c # v0.2.3
     with:
       preview-branch: scriv-preview
     secrets:


### PR DESCRIPTION
## Summary

The current pin to `scriv-release@v0.2.1` fails on every push to `main` with `scriv-release: command not found` — see [run 25321284181](https://github.com/whitphx/streamlit-webrtc/actions/runs/25321284181/job/74230680126).

## Root cause

`reusable.yml@v0.2.1` over in `whitphx/scriv-release` still references `whitphx/scriv-release@v0.2.0` for the underlying composite action. The self-reference wasn't bumped when v0.2.1 was cut. So:

- v0.2.1's reusable workflow → invokes v0.2.0's `action.yml`
- v0.2.0's action.yml has the broken default `install-spec: scriv-release[bump-my-version]` (a PyPI ref that 404s)
- v0.2.1's action.yml had a fix (default empty → install from `\$GITHUB_ACTION_PATH`) but it never gets exercised through the reusable workflow

When v0.2.1's reusable passes the new empty `install-spec` through to the v0.2.0 action, the action runs `pip install --quiet ""` which is a silent no-op. The next step then can't find `scriv-release` on PATH.

## Fix

`whitphx/scriv-release@v0.2.3` (just released) sets `reusable.yml`'s self-reference to `@v0.2.3`, so reusable.yml@v0.2.3 invokes action.yml@v0.2.3 — the install-fix action. This PR repins.

## Test plan

- [ ] Merge and watch the next push to `main` — the Changelog workflow should run cleanly (no fragments → no-op).
- [ ] Add a `scriv` fragment, push, and verify the preview PR opens on `scriv-preview`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->