### PR TITLE
fix: bump scriv-release to v0.2.4

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: whitphx/scriv-release/.github/workflows/reusable.yml@e0903b1fd894bc1a25c3eb6b02e5c3581d7b8a6c # v0.2.3
+    uses: whitphx/scriv-release/.github/workflows/reusable.yml@8931f7412ef30b753ab73d35c4dc2ccb8d6bdcf4 # v0.2.4
     with:
       preview-branch: scriv-preview
     secrets:


### PR DESCRIPTION
## Summary

The Changelog workflow on `main` still fails after #2395 — see [run 25359107851](https://github.com/whitphx/streamlit-webrtc/actions/runs/25359107851/job/74354527097). The install bug is gone, the release path runs, and now the `git push origin HEAD --follow-tags` step in scriv-release's `maybe-tag-release.sh` fails:

```
error: The destination you provided is not a full refname (i.e., starting with "refs/")
hint: Did you mean to create a new branch by pushing to 'HEAD:refs/heads/HEAD'?
error: failed to push some refs
```

`actions/checkout` puts the runner in detached HEAD; git 2.53+ refuses to resolve `HEAD` to a remote branch from there. The original streamlit-webrtc workflow probably worked on an older git.

## Fix

`whitphx/scriv-release@v0.2.4` (just released) reworks the release-tag push:

- `bump-my-version` runs with `--no-commit --tag`, so no commit is created — only a local tag.
- The script now pushes that tag directly via `git push origin refs/tags/<tag>` instead of `git push origin HEAD --follow-tags`.

## Recovery for the missed release

Even after this PR merges, the release that should have happened on the previous main commit won't be re-triggered automatically (HEAD~1 from the next push won't have fragments). To recover, after this merges, manually run on `main`:

```bash
uv run bump-my-version bump patch --tag --no-commit
git push origin "refs/tags/$(git describe --tags --exact-match HEAD)"
```

…assuming `patch` is the correct level for the missed release (Chore fragment from #2394).

## Test plan

- [ ] Merge this PR.
- [ ] Manually push the missed `v0.64.7` tag (commands above).
- [ ] Verify the next `scriv create` → push → preview-PR → merge cycle succeeds end-to-end on the new v0.2.4 ref.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow automation version for internal release processes.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->