### PR TITLE
ci: migrate to scriv-release v0.3.0 (composite action only)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,6 @@
 name: Changelog
-# Changelog and release management inspired by Changesets, delegated to
-# the scriv-release reusable workflow:
-#   https://github.com/whitphx/scriv-release
+# Changelog and release management inspired by Changesets.
+# https://github.com/whitphx/scriv-release
 #
 # 1. Pushes to `main` that include a changelog fragment under
 #    `changelog.d/` open (or update) a "Changelog Preview" PR.
@@ -18,12 +17,20 @@ permissions: {}
 
 jobs:
   release:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    uses: whitphx/scriv-release/.github/workflows/reusable.yml@8931f7412ef30b753ab73d35c4dc2ccb8d6bdcf4 # v0.2.4
-    with:
-      preview-branch: scriv-preview
-    secrets:
-      app-id: ${{ vars.MY_CHANGESETS_APP_ID }}
-      app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run scriv-release
+        uses: whitphx/scriv-release@31da80e50064bc5f9d3f631f51264c532fa18747 # v0.3.0
+        with:
+          app-id: ${{ vars.MY_CHANGESETS_APP_ID }}
+          app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}
+          preview-branch: scriv-preview


### PR DESCRIPTION
## Summary

`whitphx/scriv-release@v0.3.0` drops the reusable workflow shape and ships only the composite action. This PR migrates this repo's `changelog.yml` to call the action directly.

## Why scriv-release dropped the reusable workflow

The reusable workflow had to embed `uses: whitphx/scriv-release@<sha>` to reach the underlying composite action. `github.workflow_ref` in a reusable workflow reflects the **caller's** entry-point workflow, not the called workflow itself, so there's no runtime way for reusable.yml to resolve its own ref. Every scriv-release release commit therefore had to bump that line in lockstep with the new tag.

The lockstep got missed at v0.2.1 and v0.2.2, surfacing here:
- [run 25321284181](https://github.com/whitphx/streamlit-webrtc/actions/runs/25321284181) — reusable.yml@v0.2.1 was still calling action.yml@v0.2.0 (broken default install) → `scriv-release: command not found`.
- [run 25359107851](https://github.com/whitphx/streamlit-webrtc/actions/runs/25359107851) — `git push origin HEAD --follow-tags` fails on git 2.53+ in detached HEAD; fixed in v0.2.4.

With v0.3.0, action.yml is the single source of truth. `$GITHUB_ACTION_PATH` resolves correctly to the action's checked-out source, so the install fallback (`pip install $GITHUB_ACTION_PATH[bump-my-version]`) and the bash scripts both stay version-consistent automatically. No more cross-ref bug class.

## What changes here

`.github/workflows/changelog.yml`:

- `uses: whitphx/scriv-release/.github/workflows/reusable.yml@<sha>` → an explicit `runs-on` + `steps` job that does its own `actions/checkout` and calls `whitphx/scriv-release@31da80e # v0.3.0`.
- Functionally identical: same `MY_CHANGESETS_APP_ID` / `MY_CHANGESETS_APP_PRIVATE_KEY`, same `scriv-preview` branch.
- ~7 extra lines.

## Test plan

- [ ] Merge.
- [ ] Push to `main` (no fragments) — expect a clean no-op run.
- [ ] `scriv create` a fragment, push — expect a preview PR on `scriv-preview`.
- [ ] Merge the preview PR — expect a `vX.Y.Z` tag pushed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to streamline the automated release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->