### PR TITLE
Add Claude-driven issue triage and implementation workflows

### DIFF
--- a/.github/workflows/claude-issue-implement.yml
+++ b/.github/workflows/claude-issue-implement.yml
@@ -37,7 +37,7 @@ jobs:
             ## Procedure
 
             1. **Read existing conventions first (mandatory)**
-               - Always read `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` at the repository root.
+               - Always read `CLAUDE.md` and `CONTRIBUTING.md` at the repository root.
                - Read any additional rules under `.claude/` if present.
                - Never make changes that violate these documents.
 
@@ -47,7 +47,7 @@ jobs:
                - Use grep / glob to explore the relevant code.
 
             3. **Create a working branch**
-               - Run `git checkout -b claude/issue-${{ github.event.issue.number }}`.
+               - Run `git switch -c claude/issue-${{ github.event.issue.number }}`.
 
             4. **Implement**
                - For new Python dependencies, use `uv add <pkg>` (or `--dev`) so that `uv.lock` is updated.

--- a/.github/workflows/claude-issue-implement.yml
+++ b/.github/workflows/claude-issue-implement.yml
@@ -1,0 +1,124 @@
+name: Claude Issue Implement
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'ai-implement'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Run Claude implementation
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash,Edit,Write,Read,Grep,Glob"
+          direct_prompt: |
+            あなたは `whitphx/streamlit-webrtc` リポジトリで、ラベル `ai-implement` が付いた Issue を実装する担当です。
+            対象 Issue 番号: #${{ github.event.issue.number }}
+
+            ## 手順
+
+            1. **既存規約の読み込み（必須・最初に行う）**
+               - リポジトリルートの `CLAUDE.md`、`AGENTS.md`、`CONTRIBUTING.md` を必ず読む
+               - `.claude/` 配下に追加ルールがあれば読む
+               - これらに違反する変更は絶対に行わない
+
+            2. **Issue 内容の調査**
+               - `gh issue view ${{ github.event.issue.number }}` で Issue 本文・コメント・ラベル・関連 Issue/PR を確認する
+               - `gh search issues --repo whitphx/streamlit-webrtc <キーワード>` や `gh search prs` で関連する過去の議論を確認する
+               - grep / glob で関連コードを調査する
+
+            3. **作業ブランチを作成**
+               - `git checkout -b claude/issue-${{ github.event.issue.number }}` でブランチを切る
+
+            4. **実装**
+               - Python の依存追加が必要な場合は `uv add <pkg>`（または `--dev`）で追加し、`uv.lock` も更新する
+               - フロントエンドに変更がある場合は `streamlit_webrtc/frontend` で `pnpm install` してから作業する
+               - **公開 API の破壊的変更を避ける**: `webrtc_streamer()` の引数、`VideoProcessorBase` / `AudioProcessorBase` の互換性、`WebRtcStreamerContext` のインターフェースは特に慎重に扱う
+               - 破壊的変更が必要、もしくは設計判断が不明瞭な場合は **実装を進めずに Issue にコメントで質問する** こと
+
+            5. **テスト**
+               - テストを追加・更新し、`uv run pytest` がすべて通ることを確認する
+               - フロントエンドに変更がある場合は `cd streamlit_webrtc/frontend && pnpm run build` が通ることも確認する
+
+            6. **リンタ・フォーマッタ**
+               - `pre-commit run --all-files` を実行する（または `uv run ruff check . --fix` と `uv run ruff format .`）
+               - `uv run mypy .` も通すこと
+
+            7. **changelog fragment の追加（必須）**
+               - `changelog.d/` 配下の既存エントリの命名・書式を踏襲して新しいエントリファイルを追加する
+               - `scriv` 管理なので、既存エントリを参照して書式を合わせること
+               - ユーザー影響のある変更は必ずエントリを追加する
+
+            8. **PR 作成**
+               - コミットして push し、`gh pr create` で PR を作成する
+               - PR 本文に `Closes #${{ github.event.issue.number }}` を含める
+               - 変更概要・設計判断・テスト方針・後方互換性への影響を記載する
+               - フロントエンドのビルド成果物（`streamlit_webrtc/frontend/dist` など）は `.gitignore` を確認し、リポジトリの慣習に従う（コミットしない方針が標準）
+
+            ## 中断条件（以下に該当したら実装を止めて Issue にコメントする）
+
+            - 公開 API に破壊的変更が必要
+            - 新しい依存パッケージの追加が必要
+            - 設計判断が複数あり、メンテナの判断が必要
+            - Issue 内容が不明瞭で実装に必要な情報が足りない
+
+  wontfix:
+    if: github.event.label.name == 'wontfix'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude wontfix response
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(gh issue:*),Bash(gh search:*)"
+          direct_prompt: |
+            あなたは `whitphx/streamlit-webrtc` リポジトリで `wontfix` ラベルが付与された Issue に対し、丁寧な説明コメントを投稿してクローズする担当です。
+            対象 Issue 番号: #${{ github.event.issue.number }}
+
+            ## 手順
+
+            1. `gh issue view ${{ github.event.issue.number }}` で Issue 内容を取得する
+            2. `README.md`、`CONTRIBUTING.md` を読み、プロジェクトの方針を把握する
+            3. `gh issue list --repo whitphx/streamlit-webrtc --label wontfix --state closed --limit 20` などで過去の wontfix 事例を確認し、どんな理由で見送られているかの傾向を掴む
+            4. 報告者の使用言語（日本語/英語など）を判定する
+
+            ## コメント内容
+
+            - **なぜ実装しない判断になったか** を丁寧かつ建設的に説明する
+            - **代替策を提案** する。例:
+              - Streamlit ネイティブ機能で代替できないか
+              - `aiortc` を直接利用する選択肢
+              - 姉妹プロジェクト（例: `streamlit-fesion` など）が適しているケース
+              - ユーザー側ワークアラウンド（callback の使い方、TURN サーバー設定、`rtc_configuration` 調整）
+              - fork して独自に拡張する選択肢
+            - 報告者の言語に合わせる
+            - 攻撃的・冷たい表現にならないよう配慮する
+
+            ## アクション
+
+            - `gh issue comment ${{ github.event.issue.number }} --body "..."` でコメントを投稿
+            - `gh issue close ${{ github.event.issue.number }}` で Issue をクローズ

--- a/.github/workflows/claude-issue-implement.yml
+++ b/.github/workflows/claude-issue-implement.yml
@@ -31,55 +31,55 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash,Edit,Write,Read,Grep,Glob"
           direct_prompt: |
-            あなたは `whitphx/streamlit-webrtc` リポジトリで、ラベル `ai-implement` が付いた Issue を実装する担当です。
-            対象 Issue 番号: #${{ github.event.issue.number }}
+            You are the implementation agent for issues labeled `ai-implement` in the `whitphx/streamlit-webrtc` repository.
+            Target issue number: #${{ github.event.issue.number }}
 
-            ## 手順
+            ## Procedure
 
-            1. **既存規約の読み込み（必須・最初に行う）**
-               - リポジトリルートの `CLAUDE.md`、`AGENTS.md`、`CONTRIBUTING.md` を必ず読む
-               - `.claude/` 配下に追加ルールがあれば読む
-               - これらに違反する変更は絶対に行わない
+            1. **Read existing conventions first (mandatory)**
+               - Always read `CLAUDE.md`, `AGENTS.md`, and `CONTRIBUTING.md` at the repository root.
+               - Read any additional rules under `.claude/` if present.
+               - Never make changes that violate these documents.
 
-            2. **Issue 内容の調査**
-               - `gh issue view ${{ github.event.issue.number }}` で Issue 本文・コメント・ラベル・関連 Issue/PR を確認する
-               - `gh search issues --repo whitphx/streamlit-webrtc <キーワード>` や `gh search prs` で関連する過去の議論を確認する
-               - grep / glob で関連コードを調査する
+            2. **Investigate the issue**
+               - Use `gh issue view ${{ github.event.issue.number }}` to inspect the body, comments, labels, and linked issues/PRs.
+               - Use `gh search issues --repo whitphx/streamlit-webrtc <keywords>` and `gh search prs` to find related historical discussions.
+               - Use grep / glob to explore the relevant code.
 
-            3. **作業ブランチを作成**
-               - `git checkout -b claude/issue-${{ github.event.issue.number }}` でブランチを切る
+            3. **Create a working branch**
+               - Run `git checkout -b claude/issue-${{ github.event.issue.number }}`.
 
-            4. **実装**
-               - Python の依存追加が必要な場合は `uv add <pkg>`（または `--dev`）で追加し、`uv.lock` も更新する
-               - フロントエンドに変更がある場合は `streamlit_webrtc/frontend` で `pnpm install` してから作業する
-               - **公開 API の破壊的変更を避ける**: `webrtc_streamer()` の引数、`VideoProcessorBase` / `AudioProcessorBase` の互換性、`WebRtcStreamerContext` のインターフェースは特に慎重に扱う
-               - 破壊的変更が必要、もしくは設計判断が不明瞭な場合は **実装を進めずに Issue にコメントで質問する** こと
+            4. **Implement**
+               - For new Python dependencies, use `uv add <pkg>` (or `--dev`) so that `uv.lock` is updated.
+               - When the frontend is involved, run `pnpm install` inside `streamlit_webrtc/frontend` before working.
+               - **Avoid breaking changes to the public API**: be especially cautious with `webrtc_streamer()` arguments, the `VideoProcessorBase` / `AudioProcessorBase` contract, and the `WebRtcStreamerContext` interface.
+               - If a breaking change appears unavoidable, or if a design decision is unclear, **stop the implementation and ask the maintainer in an issue comment**.
 
-            5. **テスト**
-               - テストを追加・更新し、`uv run pytest` がすべて通ることを確認する
-               - フロントエンドに変更がある場合は `cd streamlit_webrtc/frontend && pnpm run build` が通ることも確認する
+            5. **Test**
+               - Add or update tests and confirm `uv run pytest` passes.
+               - When the frontend is touched, also confirm `cd streamlit_webrtc/frontend && pnpm run build` succeeds.
 
-            6. **リンタ・フォーマッタ**
-               - `pre-commit run --all-files` を実行する（または `uv run ruff check . --fix` と `uv run ruff format .`）
-               - `uv run mypy .` も通すこと
+            6. **Linters / formatters**
+               - Run `pre-commit run --all-files` (or `uv run ruff check . --fix` and `uv run ruff format .`).
+               - Also ensure `uv run mypy .` passes.
 
-            7. **changelog fragment の追加（必須）**
-               - `changelog.d/` 配下の既存エントリの命名・書式を踏襲して新しいエントリファイルを追加する
-               - `scriv` 管理なので、既存エントリを参照して書式を合わせること
-               - ユーザー影響のある変更は必ずエントリを追加する
+            7. **Add a changelog fragment (mandatory)**
+               - Add a new entry under `changelog.d/`, following the naming and format used by existing entries.
+               - The directory is managed by `scriv`; mirror the format you observe in existing fragments.
+               - Any user-visible change must come with a fragment.
 
-            8. **PR 作成**
-               - コミットして push し、`gh pr create` で PR を作成する
-               - PR 本文に `Closes #${{ github.event.issue.number }}` を含める
-               - 変更概要・設計判断・テスト方針・後方互換性への影響を記載する
-               - フロントエンドのビルド成果物（`streamlit_webrtc/frontend/dist` など）は `.gitignore` を確認し、リポジトリの慣習に従う（コミットしない方針が標準）
+            8. **Open a PR**
+               - Commit, push, and run `gh pr create`.
+               - Include `Closes #${{ github.event.issue.number }}` in the PR body.
+               - Document the change summary, design decisions, test plan, and backward-compatibility impact.
+               - For frontend build artifacts (e.g., `streamlit_webrtc/frontend/dist`), follow the repository's convention by checking `.gitignore` (the convention is *not* to commit them).
 
-            ## 中断条件（以下に該当したら実装を止めて Issue にコメントする）
+            ## Stop conditions (halt the implementation and post a comment on the issue)
 
-            - 公開 API に破壊的変更が必要
-            - 新しい依存パッケージの追加が必要
-            - 設計判断が複数あり、メンテナの判断が必要
-            - Issue 内容が不明瞭で実装に必要な情報が足りない
+            - A breaking public-API change is required.
+            - A new third-party dependency must be added.
+            - There are multiple plausible design choices and maintainer input is needed.
+            - The issue is unclear and lacks information necessary to implement.
 
   wontfix:
     if: github.event.label.name == 'wontfix'
@@ -96,29 +96,29 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(gh issue:*),Bash(gh search:*)"
           direct_prompt: |
-            あなたは `whitphx/streamlit-webrtc` リポジトリで `wontfix` ラベルが付与された Issue に対し、丁寧な説明コメントを投稿してクローズする担当です。
-            対象 Issue 番号: #${{ github.event.issue.number }}
+            You are responsible for posting a polite explanation and closing issues that have been labeled `wontfix` on the `whitphx/streamlit-webrtc` repository.
+            Target issue number: #${{ github.event.issue.number }}
 
-            ## 手順
+            ## Procedure
 
-            1. `gh issue view ${{ github.event.issue.number }}` で Issue 内容を取得する
-            2. `README.md`、`CONTRIBUTING.md` を読み、プロジェクトの方針を把握する
-            3. `gh issue list --repo whitphx/streamlit-webrtc --label wontfix --state closed --limit 20` などで過去の wontfix 事例を確認し、どんな理由で見送られているかの傾向を掴む
-            4. 報告者の使用言語（日本語/英語など）を判定する
+            1. Run `gh issue view ${{ github.event.issue.number }}` to read the issue.
+            2. Read `README.md` and `CONTRIBUTING.md` to understand the project's direction.
+            3. Run `gh issue list --repo whitphx/streamlit-webrtc --label wontfix --state closed --limit 20` (or similar) to learn the kinds of reasons past issues were declined.
+            4. Detect the reporter's language.
 
-            ## コメント内容
+            ## Comment content
 
-            - **なぜ実装しない判断になったか** を丁寧かつ建設的に説明する
-            - **代替策を提案** する。例:
-              - Streamlit ネイティブ機能で代替できないか
-              - `aiortc` を直接利用する選択肢
-              - 姉妹プロジェクト（例: `streamlit-fesion` など）が適しているケース
-              - ユーザー側ワークアラウンド（callback の使い方、TURN サーバー設定、`rtc_configuration` 調整）
-              - fork して独自に拡張する選択肢
-            - 報告者の言語に合わせる
-            - 攻撃的・冷たい表現にならないよう配慮する
+            - Explain **why we decided not to implement this** in a polite and constructive tone.
+            - **Suggest alternatives**, for example:
+              - Whether native Streamlit features can solve it
+              - Using `aiortc` directly
+              - Sister projects (e.g., `streamlit-fesion`) that may fit better
+              - User-side workarounds (callback usage, TURN server configuration, `rtc_configuration` adjustments)
+              - Forking the project for custom extensions
+            - Match the reporter's language.
+            - Avoid harsh or dismissive wording.
 
-            ## アクション
+            ## Action
 
-            - `gh issue comment ${{ github.event.issue.number }} --body "..."` でコメントを投稿
-            - `gh issue close ${{ github.event.issue.number }}` で Issue をクローズ
+            - Post the comment with `gh issue comment ${{ github.event.issue.number }} --body "..."`.
+            - Close the issue with `gh issue close ${{ github.event.issue.number }}`.

--- a/.github/workflows/claude-issue-implement.yml
+++ b/.github/workflows/claude-issue-implement.yml
@@ -13,20 +13,20 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
 
       - name: Run Claude implementation
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash,Edit,Write,Read,Grep,Glob"
@@ -88,10 +88,12 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Claude wontfix response
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(gh issue:*),Bash(gh search:*)"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,0 +1,89 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  triage:
+    if: github.event.issue.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Claude triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_tools: "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*)"
+          direct_prompt: |
+            あなたは `whitphx/streamlit-webrtc` リポジトリの Issue トリアージ担当です。
+            対象 Issue 番号: #${{ github.event.issue.number }}
+
+            ## このリポジトリの前提
+
+            - `streamlit-webrtc` は Streamlit 上でリアルタイムに音声・映像を扱う Python ライブラリ（WebRTC ベース）
+            - Python バックエンド (`streamlit_webrtc/`) と React/TypeScript フロントエンド (`streamlit_webrtc/frontend/`) で構成
+            - 内部で `aiortc`, `PyAV` を利用しており、それらに起因するバグが報告されることもある
+
+            ## よくある報告分類
+
+            - カメラ/マイクが起動しない（ブラウザ権限・HTTPS 要件）
+            - デプロイ環境（Streamlit Community Cloud / Heroku / 自前サーバー等）での接続失敗（多くは TURN サーバー設定不足）
+            - `webrtc_streamer` の引数や `VideoProcessorBase` / `AudioProcessorBase` の使い方の質問
+            - フロントエンド側の表示崩れ
+            - `aiortc` / `PyAV` 由来のバグの可能性
+            - `streamlit` 本体のバージョン互換性
+
+            ## 判定手順
+
+            1. まず `gh issue view ${{ github.event.issue.number }}` で Issue 本文と既存コメントを取得する
+            2. `gh label list` で既存ラベルを確認する
+            3. `gh search issues --repo whitphx/streamlit-webrtc <キーワード>` で類似の過去 Issue を確認し、過去どう扱われたかを参考にする
+            4. 報告者が使っている言語（日本語/英語など）を判定する
+
+            ## 判定基準
+
+            **バグ報告の場合、以下が揃っているか確認:**
+            - 再現手順
+            - 期待される動作
+            - 実際の動作
+            - `streamlit-webrtc` のバージョン
+            - `streamlit` のバージョン
+            - Python バージョン
+            - OS
+            - ブラウザ
+            - デプロイ環境（ローカル / Community Cloud / 自前サーバー / Docker など）
+            - 最小再現コードの有無
+
+            **機能要望の場合、以下が揃っているか確認:**
+            - ユースケース（なぜ必要か）
+            - 現状の回避策の有無
+            - 提案する解決策
+
+            ## アクション（以下のいずれか 1 つを実行）
+
+            ### A. 情報が不足している場合
+            - 報告者の使用言語に合わせて、不足項目を箇条書きで丁寧に質問するコメントを投稿する
+            - `needs-info` ラベルを付与する
+            - 例: `gh issue comment ${{ github.event.issue.number }} --body "..."`
+            - 例: `gh issue edit ${{ github.event.issue.number }} --add-label needs-info`
+
+            ### B. 情報が十分にクリアな場合
+            - 内容を 3-5 行で要約したコメントを投稿する（メンテナが素早く把握できるように）
+            - `triaged` ラベルを付与する
+
+            ### C. このプロジェクトのスコープ外の場合
+            - スコープ外の例: Streamlit 本体のバグ、aiortc/PyAV の純粋なバグ、汎用的な使い方の質問で Discussions が適切なもの、別ライブラリへの質問
+            - 適切な誘導先（Streamlit forum、aiortc/PyAV のリポジトリ、GitHub Discussions など）を案内するコメントを報告者の言語で投稿する
+            - `out-of-scope` ラベルを付与する
+
+            ## 注意事項
+
+            - コメントは丁寧で建設的なトーンを保つこと
+            - 過度に断定せず、必要なら確認のための質問を残すこと
+            - ラベルが既に付いていたり存在しない場合は、`gh label list` で確認してから付与すること

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -21,69 +21,69 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*)"
           direct_prompt: |
-            あなたは `whitphx/streamlit-webrtc` リポジトリの Issue トリアージ担当です。
-            対象 Issue 番号: #${{ github.event.issue.number }}
+            You are the issue triage agent for the `whitphx/streamlit-webrtc` repository.
+            Target issue number: #${{ github.event.issue.number }}
 
-            ## このリポジトリの前提
+            ## Repository context
 
-            - `streamlit-webrtc` は Streamlit 上でリアルタイムに音声・映像を扱う Python ライブラリ（WebRTC ベース）
-            - Python バックエンド (`streamlit_webrtc/`) と React/TypeScript フロントエンド (`streamlit_webrtc/frontend/`) で構成
-            - 内部で `aiortc`, `PyAV` を利用しており、それらに起因するバグが報告されることもある
+            - `streamlit-webrtc` is a Python library that brings real-time audio/video processing to Streamlit via WebRTC.
+            - It consists of a Python backend (`streamlit_webrtc/`) and a React/TypeScript frontend (`streamlit_webrtc/frontend/`).
+            - It depends on `aiortc` and `PyAV` internally, so reports occasionally turn out to originate from those upstream projects.
 
-            ## よくある報告分類
+            ## Common report categories
 
-            - カメラ/マイクが起動しない（ブラウザ権限・HTTPS 要件）
-            - デプロイ環境（Streamlit Community Cloud / Heroku / 自前サーバー等）での接続失敗（多くは TURN サーバー設定不足）
-            - `webrtc_streamer` の引数や `VideoProcessorBase` / `AudioProcessorBase` の使い方の質問
-            - フロントエンド側の表示崩れ
-            - `aiortc` / `PyAV` 由来のバグの可能性
-            - `streamlit` 本体のバージョン互換性
+            - Camera/microphone fails to start (browser permissions, HTTPS requirements)
+            - Connection failures in deployment environments (Streamlit Community Cloud / Heroku / self-hosted), often caused by missing TURN server configuration
+            - Usage questions about `webrtc_streamer` arguments or `VideoProcessorBase` / `AudioProcessorBase`
+            - Frontend rendering glitches
+            - Bugs that may originate from `aiortc` / `PyAV`
+            - Compatibility issues with specific `streamlit` versions
 
-            ## 判定手順
+            ## Triage procedure
 
-            1. まず `gh issue view ${{ github.event.issue.number }}` で Issue 本文と既存コメントを取得する
-            2. `gh label list` で既存ラベルを確認する
-            3. `gh search issues --repo whitphx/streamlit-webrtc <キーワード>` で類似の過去 Issue を確認し、過去どう扱われたかを参考にする
-            4. 報告者が使っている言語（日本語/英語など）を判定する
+            1. Run `gh issue view ${{ github.event.issue.number }}` to fetch the issue body and existing comments.
+            2. Run `gh label list` to enumerate existing labels.
+            3. Run `gh search issues --repo whitphx/streamlit-webrtc <keywords>` to find similar past issues and learn how they were handled.
+            4. Detect the language used by the reporter (English, Japanese, etc.).
 
-            ## 判定基準
+            ## Evaluation criteria
 
-            **バグ報告の場合、以下が揃っているか確認:**
-            - 再現手順
-            - 期待される動作
-            - 実際の動作
-            - `streamlit-webrtc` のバージョン
-            - `streamlit` のバージョン
-            - Python バージョン
+            **For bug reports, check whether the following are present:**
+            - Reproduction steps
+            - Expected behavior
+            - Actual behavior
+            - `streamlit-webrtc` version
+            - `streamlit` version
+            - Python version
             - OS
-            - ブラウザ
-            - デプロイ環境（ローカル / Community Cloud / 自前サーバー / Docker など）
-            - 最小再現コードの有無
+            - Browser
+            - Deployment environment (local / Community Cloud / self-hosted / Docker, etc.)
+            - Minimal reproducible example
 
-            **機能要望の場合、以下が揃っているか確認:**
-            - ユースケース（なぜ必要か）
-            - 現状の回避策の有無
-            - 提案する解決策
+            **For feature requests, check whether the following are present:**
+            - Use case (why it is needed)
+            - Existing workarounds (if any)
+            - Proposed solution
 
-            ## アクション（以下のいずれか 1 つを実行）
+            ## Action (perform exactly one of the following)
 
-            ### A. 情報が不足している場合
-            - 報告者の使用言語に合わせて、不足項目を箇条書きで丁寧に質問するコメントを投稿する
-            - `needs-info` ラベルを付与する
-            - 例: `gh issue comment ${{ github.event.issue.number }} --body "..."`
-            - 例: `gh issue edit ${{ github.event.issue.number }} --add-label needs-info`
+            ### A. Information is missing
+            - Post a polite comment in the reporter's language listing the missing items as bullet points.
+            - Add the `needs-info` label.
+            - Examples: `gh issue comment ${{ github.event.issue.number }} --body "..."`,
+              `gh issue edit ${{ github.event.issue.number }} --add-label needs-info`.
 
-            ### B. 情報が十分にクリアな場合
-            - 内容を 3-5 行で要約したコメントを投稿する（メンテナが素早く把握できるように）
-            - `triaged` ラベルを付与する
+            ### B. Information is sufficiently clear
+            - Post a 3-5 line summary comment so the maintainer can grasp the situation quickly.
+            - Add the `triaged` label.
 
-            ### C. このプロジェクトのスコープ外の場合
-            - スコープ外の例: Streamlit 本体のバグ、aiortc/PyAV の純粋なバグ、汎用的な使い方の質問で Discussions が適切なもの、別ライブラリへの質問
-            - 適切な誘導先（Streamlit forum、aiortc/PyAV のリポジトリ、GitHub Discussions など）を案内するコメントを報告者の言語で投稿する
-            - `out-of-scope` ラベルを付与する
+            ### C. Out of scope for this project
+            - Examples of out-of-scope: bugs in Streamlit itself, bugs purely in aiortc/PyAV, generic usage questions better suited for Discussions, questions about other libraries.
+            - Post a comment in the reporter's language pointing them to the appropriate destination (Streamlit forum, aiortc/PyAV repository, GitHub Discussions, etc.).
+            - Add the `out-of-scope` label.
 
-            ## 注意事項
+            ## Notes
 
-            - コメントは丁寧で建設的なトーンを保つこと
-            - 過度に断定せず、必要なら確認のための質問を残すこと
-            - ラベルが既に付いていたり存在しない場合は、`gh label list` で確認してから付与すること
+            - Keep the tone polite and constructive at all times.
+            - Avoid being overly assertive; ask clarifying questions when uncertain.
+            - Before adding a label, verify with `gh label list` that it exists and is not already applied.

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -13,10 +13,12 @@ jobs:
     if: github.event.issue.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Claude triage
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_tools: "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,3 +123,15 @@ pnpm run build
 - STUN/TURN server configuration via `rtc_configuration`
 - Default uses Google's public STUN server
 - Production deployments may need TURN servers (e.g., Twilio)
+
+## OSS Issue 自動対応の運用規約
+
+このリポジトリでは GitHub Actions 経由で Claude が Issue の一次対応と実装の一部を担います。Claude が Issue 起点で作業する際は以下を遵守してください。
+
+- **公開 API の破壊的変更は避ける**: `webrtc_streamer()` の引数、`VideoProcessorBase` / `AudioProcessorBase` の互換性、`WebRtcStreamerContext` のインターフェースは特に慎重に扱う。破壊的変更が必要な場合は実装を止めて Issue で議論を促す
+- **依存パッケージの追加は要相談**: `pyproject.toml` への新規依存追加は事前に Issue で合意を得る。可能なら標準ライブラリで解決する
+- **ライセンス互換性**: MIT 互換でないコード断片を持ち込まない
+- **changelog fragment を必ず追加**: ユーザー影響のある変更は `changelog.d/` にエントリを追加する
+- **テストとリンタ**: `uv run pytest` と `pre-commit run --all-files` がローカルで通ることを確認してから PR を出す
+- **不明瞭な設計判断は実装を止めて Issue でメンテナに質問する**
+- **Streamlit / aiortc / PyAV のバージョン互換性**: 既存の `pyproject.toml` の依存範囲を尊重し、必要な場合のみ慎重に拡張する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,14 +124,14 @@ pnpm run build
 - Default uses Google's public STUN server
 - Production deployments may need TURN servers (e.g., Twilio)
 
-## OSS Issue 自動対応の運用規約
+## OSS Issue Automation Rules
 
-このリポジトリでは GitHub Actions 経由で Claude が Issue の一次対応と実装の一部を担います。Claude が Issue 起点で作業する際は以下を遵守してください。
+This repository uses GitHub Actions to let Claude handle initial issue triage and a portion of the implementation work. When Claude works from an issue, follow these rules:
 
-- **公開 API の破壊的変更は避ける**: `webrtc_streamer()` の引数、`VideoProcessorBase` / `AudioProcessorBase` の互換性、`WebRtcStreamerContext` のインターフェースは特に慎重に扱う。破壊的変更が必要な場合は実装を止めて Issue で議論を促す
-- **依存パッケージの追加は要相談**: `pyproject.toml` への新規依存追加は事前に Issue で合意を得る。可能なら標準ライブラリで解決する
-- **ライセンス互換性**: MIT 互換でないコード断片を持ち込まない
-- **changelog fragment を必ず追加**: ユーザー影響のある変更は `changelog.d/` にエントリを追加する
-- **テストとリンタ**: `uv run pytest` と `pre-commit run --all-files` がローカルで通ることを確認してから PR を出す
-- **不明瞭な設計判断は実装を止めて Issue でメンテナに質問する**
-- **Streamlit / aiortc / PyAV のバージョン互換性**: 既存の `pyproject.toml` の依存範囲を尊重し、必要な場合のみ慎重に拡張する
+- **Avoid breaking changes to the public API**: be especially careful with `webrtc_streamer()` arguments, the `VideoProcessorBase` / `AudioProcessorBase` contract, and the `WebRtcStreamerContext` interface. If a breaking change is required, stop the implementation and ask for discussion in the issue.
+- **Discuss new dependencies first**: any new entry in `pyproject.toml` must be agreed upon in the issue beforehand. Prefer the standard library when possible.
+- **License compatibility**: do not bring in code that is not MIT-compatible.
+- **Always add a changelog fragment**: add an entry under `changelog.d/` for any user-visible change.
+- **Tests and linters**: confirm that `uv run pytest` and `pre-commit run --all-files` pass locally before opening a PR.
+- **Stop on unclear design decisions**: when in doubt, stop and ask the maintainer in the issue.
+- **Streamlit / aiortc / PyAV compatibility**: respect the existing dependency ranges in `pyproject.toml` and only widen them carefully when truly necessary.

--- a/docs/ai-issue-workflow.md
+++ b/docs/ai-issue-workflow.md
@@ -1,119 +1,117 @@
-# AI Issue 自動対応ワークフロー
+# AI Issue Automation Workflow
 
-このリポジトリでは、外部から届く Issue の一次対応コストを下げるために、`anthropics/claude-code-action` を中核とした GitHub Actions ベースのワークフローを導入しています。本ドキュメントでは、その全体像と運用方法を記載します。
+This repository ships a GitHub Actions–based workflow centered on `anthropics/claude-code-action` to lower the cost of the initial response to incoming issues. It narrows the maintainer's decision surface to a single question — "should we implement this or not?" — and automates triage, requesting missing information, implementation, and the wontfix reply.
 
-## 概要
-
-人間（メンテナ）の判断ポイントは「実装するか／しないか」のラベル付けのみに絞り、トリアージ・不足情報の問い返し・実装・wontfix 時の返信は自動化しています。
+## Overview
 
 ```
-Issue 作成
+Issue created
     ↓
 [claude-issue-triage] ──→ needs-info / triaged / out-of-scope
                                    ↓
-                           （メンテナがラベル付与）
+                          (maintainer applies a label)
                                    ↓
                        ai-implement ─→ [implement] ─→ PR
-                       wontfix      ─→ [wontfix]   ─→ クローズ
+                       wontfix      ─→ [wontfix]   ─→ closed
 ```
 
-### 1. トリアージフェーズ (`claude-issue-triage.yml`)
+### 1. Triage phase (`claude-issue-triage.yml`)
 
-`issues.opened` をトリガーに発火します。Claude が Issue 内容を読み、以下のいずれかに振り分けます。
+Triggered by `issues.opened`. Claude reads the issue and routes it into one of:
 
-- **`needs-info`**: 再現手順・期待動作・実環境情報などが不足している場合。報告者の言語に合わせて、不足項目を箇条書きで質問するコメントを投稿します。
-- **`triaged`**: 内容が十分にクリアな場合。3-5 行の要約コメントを投稿し、メンテナが素早く把握できる状態にします。
-- **`out-of-scope`**: Streamlit 本体・aiortc・PyAV など別プロジェクトに属する問題、もしくは GitHub Discussions が適切なサポート質問の場合。誘導コメントを投稿します。
+- **`needs-info`**: required information (reproduction steps, expected behavior, environment, etc.) is missing. Claude posts a polite comment listing the missing items in the reporter's language.
+- **`triaged`**: the report is already actionable. Claude posts a 3-5 line summary so the maintainer can grasp it at a glance.
+- **`out-of-scope`**: the issue belongs to a different project (Streamlit core, aiortc, PyAV) or is a support question better suited for GitHub Discussions. Claude posts a redirection comment.
 
-ボット由来の Issue は `github.event.issue.user.type != 'Bot'` で除外しています。
+Bot-authored issues are skipped via `github.event.issue.user.type != 'Bot'`.
 
-### 2. ラベル駆動の実装フェーズ (`claude-issue-implement.yml`)
+### 2. Label-driven implementation phase (`claude-issue-implement.yml`)
 
-`issues.labeled` をトリガーに発火し、ラベル名で分岐します。
+Triggered by `issues.labeled`, with two jobs that branch on the label name:
 
-- **`ai-implement`**: メンテナが「実装してよい」と判断した Issue。Claude が実装ブランチ (`claude/issue-<番号>`) を作成し、テスト・リンタ・changelog fragment 追加まで行ってから PR を作成します。
-- **`wontfix`**: メンテナが「対応しない」と判断した Issue。Claude が理由を丁寧に説明し、代替策を提案するコメントを投稿してから Issue をクローズします。
+- **`ai-implement`**: the maintainer has approved implementation. Claude creates an implementation branch (`claude/issue-<number>`), runs tests/linters, adds a changelog fragment, and opens a PR.
+- **`wontfix`**: the maintainer has decided not to pursue the change. Claude posts a thoughtful explanation with alternatives in the reporter's language, then closes the issue.
 
-外部からの PR レビューは既存の AI レビューボットで運用しているため、本ワークフローのスコープ外です。
+External PR review is handled by an existing AI review bot and is out of scope for this workflow.
 
-## 初期セットアップ
+## Initial setup
 
-### 1. Anthropic API Key の登録
+### 1. Register the Anthropic API key
 
-GitHub リポジトリの設定で API Key を Secrets に登録します。
+Store the API key as a repository secret.
 
-1. リポジトリの **Settings → Secrets and variables → Actions** を開く
-2. **New repository secret** をクリック
-3. Name に `ANTHROPIC_API_KEY`、Value に Anthropic コンソールで発行した API Key を入力して保存
+1. Open **Settings → Secrets and variables → Actions** in the repo.
+2. Click **New repository secret**.
+3. Set the name to `ANTHROPIC_API_KEY` and the value to a key issued from the Anthropic console.
 
-### 2. ラベルの作成
+### 2. Create labels
 
-ワークフローで使うラベルを冪等に作成するスクリプトを用意しています。
+The script provisions the labels used by the workflows idempotently.
 
 ```bash
 bash scripts/setup-issue-labels.sh
 ```
 
-作成されるラベル:
+The labels created are:
 
-| name           | 用途 |
-| -------------- | ---- |
-| `needs-info`   | 報告者からの追加情報待ち（Claude が自動付与） |
-| `triaged`      | トリアージ済み・対応待ち（Claude が自動付与） |
-| `out-of-scope` | このプロジェクトのスコープ外 |
-| `ai-implement` | Claude による実装を依頼（メンテナが手動付与） |
-| `wontfix`      | 対応しない（メンテナが手動付与） |
+| name           | purpose |
+| -------------- | ------- |
+| `needs-info`   | Waiting for additional info from the reporter (auto-applied by Claude) |
+| `triaged`      | Triaged and awaiting maintainer action (auto-applied by Claude) |
+| `out-of-scope` | Out of scope for this project |
+| `ai-implement` | Request Claude to implement this issue (applied manually by the maintainer) |
+| `wontfix`      | This will not be worked on (applied manually by the maintainer) |
 
-### 3. Actions の権限設定
+### 3. Action permissions
 
-`ai-implement` ジョブが PR を作成できるように、以下を確認してください。
+So the `ai-implement` job can open PRs, confirm the following:
 
 - **Settings → Actions → General → Workflow permissions**
-  - 「Read and write permissions」が選択されていること
-  - 「Allow GitHub Actions to create and approve pull requests」にチェックが入っていること
+  - "Read and write permissions" is selected.
+  - "Allow GitHub Actions to create and approve pull requests" is enabled.
 
-## 運用ガイド
+## Operations guide
 
-### 導入直後の運用
+### The first couple of weeks
 
-最初の 2 週間は **`ai-implement` で生成された PR も必ず人間レビューを通す** こと。Claude の判断や実装パターンが想定通りか観察し、必要に応じて `direct_prompt` や `CLAUDE.md` のルールを調整します。
+Treat **every PR produced by `ai-implement` as a mandatory human-review PR** for at least the first two weeks. Observe how Claude makes decisions and adjust `direct_prompt` or `CLAUDE.md` rules as needed.
 
-観察ポイント:
+Things to watch for:
 
-- トリアージの判定精度（`needs-info` / `triaged` / `out-of-scope` の振り分けが妥当か）
-- 不足情報の質問内容が報告者にとって明確か
-- 実装 PR が CLAUDE.md / AGENTS.md の規約を守っているか
-- changelog fragment が正しく追加されているか
+- Triage classification quality (is the split between `needs-info` / `triaged` / `out-of-scope` reasonable?)
+- Whether the missing-info questions are clear to the reporter
+- Whether implementation PRs respect the conventions in CLAUDE.md / AGENTS.md
+- Whether changelog fragments are added correctly
 
-### プロンプトインジェクション対策
+### Prompt-injection mitigations
 
-- `allowed_tools` を最小化し、トリアージ・wontfix では `gh issue:*` / `gh label:*` / `gh search:*` のみ許可している
-- 実装フェーズでも `Bash,Edit,Write,Read,Grep,Glob` に限定
-- `permissions:` ブロックで必要最小限の `GITHUB_TOKEN` スコープに絞っている
+- `allowed_tools` is kept minimal: triage/wontfix only use `gh issue:*` / `gh label:*` / `gh search:*`.
+- The implementation job is limited to `Bash,Edit,Write,Read,Grep,Glob`.
+- The `permissions:` block scopes the `GITHUB_TOKEN` to the bare minimum required.
 
-Issue 本文内に悪意ある指示が混入している可能性に備え、**生成された PR は必ずレビューする** ことを徹底してください。
+Treat issue bodies as untrusted: **always review the generated PR**, since malicious instructions could be embedded in the issue body.
 
-### API 消費の抑制
+### Keeping API spend in check
 
-- ボット由来の Issue は `github.event.issue.user.type != 'Bot'` で除外
-- ノイズの多い時期は月のコストが嵩むので、必要に応じて以下のフィルタ追加を検討:
-  - Issue テンプレを使っていない Issue を除外
-  - 特定ラベル付きのみ反応させる
-  - 特定リポジトリ コラボレーター以外の Issue は人間レビューに回す
+- Bot-authored issues are skipped via `github.event.issue.user.type != 'Bot'`.
+- During noisy periods, cost can rise quickly. Consider adding filters such as:
+  - skipping issues that don't follow the issue template
+  - reacting only to issues with a specific label
+  - routing non-collaborator issues to human review instead of automation
 
-### デバッグ方法
+### Debugging
 
-ワークフローが期待通りに動かない場合:
+If the workflow does not behave as expected:
 
-1. **Actions タブのログを確認**: `Claude Issue Triage` / `Claude Issue Implement` の各ジョブログを開き、Claude が実行したコマンドと出力を確認
-2. **`direct_prompt` の調整**: 判定基準が曖昧な場合は、本ファイルが参照しているワークフロー YAML 内の `direct_prompt` を編集
-3. **`.claude/` 配下のルール追加**: 反復するミスがある場合、リポジトリの `.claude/` 配下にルールファイルを追加して恒常的に守らせる
-4. **`CLAUDE.md` への追記**: プロジェクト全体に効くガードレールは `CLAUDE.md` の「OSS Issue 自動対応の運用規約」セクションに追記
+1. **Inspect the Actions tab logs** for `Claude Issue Triage` / `Claude Issue Implement` to see the commands Claude ran and their outputs.
+2. **Tune `direct_prompt`** in the workflow YAML when triage criteria feel ambiguous.
+3. **Add rules under `.claude/`** when you observe recurring mistakes that need a durable guardrail.
+4. **Append to `CLAUDE.md`** — project-wide guardrails belong in the "OSS Issue Automation Rules" section.
 
-## コスト見積もりの考え方
+## Cost expectations
 
-トリアージは 1 件あたり Issue 本文 + コメント数件 + 関連 Issue/ラベル一覧を読む程度のトークン量で済みます。実装フェーズは規模に応じてトークン消費が大きく変動するため、月次コストはトリアージ件数よりも `ai-implement` 付与回数に強く依存します。
+Triage cost per issue is small: it reads the issue body, a few comments, and the labels/related-issue list. Implementation cost varies with the size of the change, so monthly spend tracks the number of `ai-implement` invocations more than triage volume.
 
-ノイズの多い時期は月のコストが嵩むので、必要に応じて Issue テンプレ未使用のものに絞るなどのフィルタ追加を検討してください。
+During noisy periods costs can climb, so consider tightening the filter — for example by skipping issues that don't use the issue template — when the volume becomes uncomfortable.
 
-<!-- TODO: mkdocs.yml の nav に追加してください -->
+<!-- TODO: add this page to the nav in mkdocs.yml -->

--- a/docs/ai-issue-workflow.md
+++ b/docs/ai-issue-workflow.md
@@ -1,0 +1,119 @@
+# AI Issue 自動対応ワークフロー
+
+このリポジトリでは、外部から届く Issue の一次対応コストを下げるために、`anthropics/claude-code-action` を中核とした GitHub Actions ベースのワークフローを導入しています。本ドキュメントでは、その全体像と運用方法を記載します。
+
+## 概要
+
+人間（メンテナ）の判断ポイントは「実装するか／しないか」のラベル付けのみに絞り、トリアージ・不足情報の問い返し・実装・wontfix 時の返信は自動化しています。
+
+```
+Issue 作成
+    ↓
+[claude-issue-triage] ──→ needs-info / triaged / out-of-scope
+                                   ↓
+                           （メンテナがラベル付与）
+                                   ↓
+                       ai-implement ─→ [implement] ─→ PR
+                       wontfix      ─→ [wontfix]   ─→ クローズ
+```
+
+### 1. トリアージフェーズ (`claude-issue-triage.yml`)
+
+`issues.opened` をトリガーに発火します。Claude が Issue 内容を読み、以下のいずれかに振り分けます。
+
+- **`needs-info`**: 再現手順・期待動作・実環境情報などが不足している場合。報告者の言語に合わせて、不足項目を箇条書きで質問するコメントを投稿します。
+- **`triaged`**: 内容が十分にクリアな場合。3-5 行の要約コメントを投稿し、メンテナが素早く把握できる状態にします。
+- **`out-of-scope`**: Streamlit 本体・aiortc・PyAV など別プロジェクトに属する問題、もしくは GitHub Discussions が適切なサポート質問の場合。誘導コメントを投稿します。
+
+ボット由来の Issue は `github.event.issue.user.type != 'Bot'` で除外しています。
+
+### 2. ラベル駆動の実装フェーズ (`claude-issue-implement.yml`)
+
+`issues.labeled` をトリガーに発火し、ラベル名で分岐します。
+
+- **`ai-implement`**: メンテナが「実装してよい」と判断した Issue。Claude が実装ブランチ (`claude/issue-<番号>`) を作成し、テスト・リンタ・changelog fragment 追加まで行ってから PR を作成します。
+- **`wontfix`**: メンテナが「対応しない」と判断した Issue。Claude が理由を丁寧に説明し、代替策を提案するコメントを投稿してから Issue をクローズします。
+
+外部からの PR レビューは既存の AI レビューボットで運用しているため、本ワークフローのスコープ外です。
+
+## 初期セットアップ
+
+### 1. Anthropic API Key の登録
+
+GitHub リポジトリの設定で API Key を Secrets に登録します。
+
+1. リポジトリの **Settings → Secrets and variables → Actions** を開く
+2. **New repository secret** をクリック
+3. Name に `ANTHROPIC_API_KEY`、Value に Anthropic コンソールで発行した API Key を入力して保存
+
+### 2. ラベルの作成
+
+ワークフローで使うラベルを冪等に作成するスクリプトを用意しています。
+
+```bash
+bash scripts/setup-issue-labels.sh
+```
+
+作成されるラベル:
+
+| name           | 用途 |
+| -------------- | ---- |
+| `needs-info`   | 報告者からの追加情報待ち（Claude が自動付与） |
+| `triaged`      | トリアージ済み・対応待ち（Claude が自動付与） |
+| `out-of-scope` | このプロジェクトのスコープ外 |
+| `ai-implement` | Claude による実装を依頼（メンテナが手動付与） |
+| `wontfix`      | 対応しない（メンテナが手動付与） |
+
+### 3. Actions の権限設定
+
+`ai-implement` ジョブが PR を作成できるように、以下を確認してください。
+
+- **Settings → Actions → General → Workflow permissions**
+  - 「Read and write permissions」が選択されていること
+  - 「Allow GitHub Actions to create and approve pull requests」にチェックが入っていること
+
+## 運用ガイド
+
+### 導入直後の運用
+
+最初の 2 週間は **`ai-implement` で生成された PR も必ず人間レビューを通す** こと。Claude の判断や実装パターンが想定通りか観察し、必要に応じて `direct_prompt` や `CLAUDE.md` のルールを調整します。
+
+観察ポイント:
+
+- トリアージの判定精度（`needs-info` / `triaged` / `out-of-scope` の振り分けが妥当か）
+- 不足情報の質問内容が報告者にとって明確か
+- 実装 PR が CLAUDE.md / AGENTS.md の規約を守っているか
+- changelog fragment が正しく追加されているか
+
+### プロンプトインジェクション対策
+
+- `allowed_tools` を最小化し、トリアージ・wontfix では `gh issue:*` / `gh label:*` / `gh search:*` のみ許可している
+- 実装フェーズでも `Bash,Edit,Write,Read,Grep,Glob` に限定
+- `permissions:` ブロックで必要最小限の `GITHUB_TOKEN` スコープに絞っている
+
+Issue 本文内に悪意ある指示が混入している可能性に備え、**生成された PR は必ずレビューする** ことを徹底してください。
+
+### API 消費の抑制
+
+- ボット由来の Issue は `github.event.issue.user.type != 'Bot'` で除外
+- ノイズの多い時期は月のコストが嵩むので、必要に応じて以下のフィルタ追加を検討:
+  - Issue テンプレを使っていない Issue を除外
+  - 特定ラベル付きのみ反応させる
+  - 特定リポジトリ コラボレーター以外の Issue は人間レビューに回す
+
+### デバッグ方法
+
+ワークフローが期待通りに動かない場合:
+
+1. **Actions タブのログを確認**: `Claude Issue Triage` / `Claude Issue Implement` の各ジョブログを開き、Claude が実行したコマンドと出力を確認
+2. **`direct_prompt` の調整**: 判定基準が曖昧な場合は、本ファイルが参照しているワークフロー YAML 内の `direct_prompt` を編集
+3. **`.claude/` 配下のルール追加**: 反復するミスがある場合、リポジトリの `.claude/` 配下にルールファイルを追加して恒常的に守らせる
+4. **`CLAUDE.md` への追記**: プロジェクト全体に効くガードレールは `CLAUDE.md` の「OSS Issue 自動対応の運用規約」セクションに追記
+
+## コスト見積もりの考え方
+
+トリアージは 1 件あたり Issue 本文 + コメント数件 + 関連 Issue/ラベル一覧を読む程度のトークン量で済みます。実装フェーズは規模に応じてトークン消費が大きく変動するため、月次コストはトリアージ件数よりも `ai-implement` 付与回数に強く依存します。
+
+ノイズの多い時期は月のコストが嵩むので、必要に応じて Issue テンプレ未使用のものに絞るなどのフィルタ追加を検討してください。
+
+<!-- TODO: mkdocs.yml の nav に追加してください -->

--- a/scripts/setup-issue-labels.sh
+++ b/scripts/setup-issue-labels.sh
@@ -23,10 +23,10 @@ create_or_update_label() {
 
 # Labels managed by the automation. We use --force so re-running the script
 # updates color/description if they drift.
-create_or_update_label "needs-info"   "FBCA04" "報告者からの追加情報待ち（Claude が自動付与）"
-create_or_update_label "triaged"      "0E8A16" "トリアージ済み・対応待ち（Claude が自動付与）"
-create_or_update_label "out-of-scope" "CCCCCC" "このプロジェクトのスコープ外"
-create_or_update_label "ai-implement" "1D76DB" "Claude による実装を依頼"
+create_or_update_label "needs-info"   "FBCA04" "Waiting for additional info from the reporter (auto-applied by Claude)"
+create_or_update_label "triaged"      "0E8A16" "Triaged and awaiting maintainer action (auto-applied by Claude)"
+create_or_update_label "out-of-scope" "CCCCCC" "Out of scope for this project"
+create_or_update_label "ai-implement" "1D76DB" "Request Claude to implement this issue"
 
 # `wontfix` is a conventional GitHub default label. Avoid clobbering its
 # existing color/description if it's already there.
@@ -34,7 +34,7 @@ existing_labels="$(gh label list --limit 200 --json name --jq '.[].name')"
 if echo "${existing_labels}" | grep -qx "wontfix"; then
   echo "Label 'wontfix' already exists; leaving it untouched."
 else
-  create_or_update_label "wontfix" "FFFFFF" "対応しない"
+  create_or_update_label "wontfix" "FFFFFF" "This will not be worked on"
 fi
 
 echo "Done."

--- a/scripts/setup-issue-labels.sh
+++ b/scripts/setup-issue-labels.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Usage: bash scripts/setup-issue-labels.sh
+#
+# Idempotently creates / updates the labels used by the Claude issue
+# automation workflows (.github/workflows/claude-issue-*.yml).
+#
+# Requirements:
+# - `gh` CLI authenticated against the `whitphx/streamlit-webrtc` repo
+
+set -euo pipefail
+
+create_or_update_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+
+  echo "Creating/updating label: ${name}"
+  gh label create "${name}" \
+    --color "${color}" \
+    --description "${description}" \
+    --force
+}
+
+# Labels managed by the automation. We use --force so re-running the script
+# updates color/description if they drift.
+create_or_update_label "needs-info"   "FBCA04" "報告者からの追加情報待ち（Claude が自動付与）"
+create_or_update_label "triaged"      "0E8A16" "トリアージ済み・対応待ち（Claude が自動付与）"
+create_or_update_label "out-of-scope" "CCCCCC" "このプロジェクトのスコープ外"
+create_or_update_label "ai-implement" "1D76DB" "Claude による実装を依頼"
+
+# `wontfix` is a conventional GitHub default label. Avoid clobbering its
+# existing color/description if it's already there.
+existing_labels="$(gh label list --limit 200 --json name --jq '.[].name')"
+if echo "${existing_labels}" | grep -qx "wontfix"; then
+  echo "Label 'wontfix' already exists; leaving it untouched."
+else
+  create_or_update_label "wontfix" "FFFFFF" "対応しない"
+fi
+
+echo "Done."


### PR DESCRIPTION
Introduces a two-phase automation flow for incoming issues:

- claude-issue-triage.yml: on issues.opened, classify and label (needs-info / triaged / out-of-scope) with a reply in the reporter's language.
- claude-issue-implement.yml: on issues.labeled, either implement the change and open a PR (ai-implement) or post a constructive decline and close (wontfix).

Also adds:
- scripts/setup-issue-labels.sh to idempotently provision labels
- docs/ai-issue-workflow.md as the operator-facing guide
- A CLAUDE.md section codifying guardrails (no breaking public-API changes, require changelog fragments, etc.) for issue-driven work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated issue triage and AI-assisted issue handling with distinct paths for auto-implementation and polite closure.
  * Added an idempotent setup utility to create and maintain required issue labels.

* **Documentation**
  * Added user-facing docs and guidance for the AI-driven issue workflow, setup/configuration steps, operating guidelines, governance rules, and cost/maintenance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->