### PR TITLE
ci: migrate claude-code-action workflows to v1 input shape

### DIFF
--- a/.github/workflows/claude-issue-implement.yml
+++ b/.github/workflows/claude-issue-implement.yml
@@ -12,6 +12,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -29,8 +30,8 @@ jobs:
         uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "Bash,Edit,Write,Read,Grep,Glob"
-          direct_prompt: |
+          claude_args: --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"
+          prompt: |
             You are the implementation agent for issues labeled `ai-implement` in the `whitphx/streamlit-webrtc` repository.
             Target issue number: #${{ github.event.issue.number }}
 
@@ -87,6 +88,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -96,8 +98,8 @@ jobs:
         uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "Bash(gh issue:*),Bash(gh search:*)"
-          direct_prompt: |
+          claude_args: --allowed-tools "Bash(gh issue:*),Bash(gh search:*)"
+          prompt: |
             You are responsible for posting a polite explanation and closing issues that have been labeled `wontfix` on the `whitphx/streamlit-webrtc` repository.
             Target issue number: #${{ github.event.issue.number }}
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write
 
 jobs:
   triage:
@@ -21,8 +22,8 @@ jobs:
         uses: anthropics/claude-code-action@987ec34d85571633d5c4b782331b052a56c3fc40 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*)"
-          direct_prompt: |
+          claude_args: --allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh search:*)"
+          prompt: |
             You are the issue triage agent for the `whitphx/streamlit-webrtc` repository.
             Target issue number: #${{ github.event.issue.number }}
 


### PR DESCRIPTION
## Summary

`anthropics/claude-code-action@v1` renamed two inputs and (despite docs to the contrary, in this version) requires `id-token: write` even when authenticating via `anthropic_api_key`. The current workflows hit both: the deprecated input names produce a runtime warning and are ignored, and the action then fails at the OIDC fetch with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`.

## Changes

Per call site (three of them: `claude-issue-triage.yml`, plus the `implement` and `wontfix` jobs in `claude-issue-implement.yml`):

```diff
 permissions:
   contents: read   # or write, varies per job
   issues: write
+  id-token: write
```

```diff
       uses: anthropics/claude-code-action@<sha> # v1
       with:
         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-        allowed_tools: "..."
-        direct_prompt: |
+        claude_args: --allowed-tools "..."
+        prompt: |
           ...
```

The `--allowed-tools` value is a single comma-separated string — same content as before, no list/repeated-flag conversion needed.

## Test plan

- [x] `actionlint .github/workflows/claude-*.yml` clean.
- [ ] Open a test issue (or use an existing one) to fire `claude-issue-triage.yml` and verify the run completes the `Run Claude triage` step without the OIDC or deprecation errors. Comparable test for the other two paths if convenient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configurations to improve build and automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->