### PR TITLE
Fix AudioSourceTrack time_base for non-48000 sample rates

### DIFF
--- a/changelog.d/20260511_224155_t.yic.yt.md
+++ b/changelog.d/20260511_224155_t.yic.yt.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix `AudioSourceTrack` / `create_audio_source_track` so the outbound `AudioFrame.time_base` is derived from the configured `sample_rate` instead of being hard-coded to `1/48000`. Previously, using a non-`48000` `sample_rate` caused the receiver to play audio at the wrong speed (e.g. 3× faster at `sample_rate=16000`). ([#2405](https://github.com/whitphx/streamlit-webrtc/issues/2405))

--- a/streamlit_webrtc/source.py
+++ b/streamlit_webrtc/source.py
@@ -93,6 +93,7 @@ class AudioSourceTrack(MediaStreamTrack):
         self._sample_rate = sample_rate
         self._ptime = ptime
         self._samples_per_frame = int(self._sample_rate * self._ptime)
+        self._time_base = fractions.Fraction(1, self._sample_rate)
         self._started_at: Optional[float] = None
         self._pts: Optional[int] = None
 
@@ -104,11 +105,11 @@ class AudioSourceTrack(MediaStreamTrack):
             self._started_at = time.monotonic()
             self._pts = 0
 
-            frame = self._call_callback(self._pts, AUDIO_TIME_BASE)
+            frame = self._call_callback(self._pts, self._time_base)
         else:
             self._pts += self._samples_per_frame
 
-            frame = self._call_callback(self._pts, AUDIO_TIME_BASE)
+            frame = self._call_callback(self._pts, self._time_base)
 
             wait = self._started_at + (self._pts / self._sample_rate) - time.monotonic()
             if wait < 0:

--- a/streamlit_webrtc/source.py
+++ b/streamlit_webrtc/source.py
@@ -87,6 +87,10 @@ class AudioSourceTrack(MediaStreamTrack):
         sample_rate: int = AUDIO_SAMPLE_RATE,
         ptime: float = AUDIO_PTIME,
     ) -> None:
+        if sample_rate <= 0:
+            raise ValueError(
+                f"sample_rate must be a positive integer, got {sample_rate}"
+            )
         super().__init__()
         self.kind = "audio"
         self._callback = callback

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -1,0 +1,53 @@
+import asyncio
+import fractions
+
+import av
+import numpy as np
+import pytest
+
+from streamlit_webrtc.source import AudioSourceTrack
+
+
+def _make_callback(sample_rate: int, samples_per_frame: int):
+    def callback(pts: int, time_base: fractions.Fraction) -> av.AudioFrame:
+        samples = np.zeros((1, samples_per_frame), dtype=np.int16)
+        frame = av.AudioFrame.from_ndarray(samples, format="s16", layout="mono")
+        frame.sample_rate = sample_rate
+        return frame
+
+    return callback
+
+
+@pytest.mark.parametrize("sample_rate", [8000, 16000, 44100, 48000])
+def test_audio_source_track_time_base_matches_sample_rate(sample_rate: int) -> None:
+    """frame.pts * frame.time_base must advance by exactly ptime seconds per call.
+
+    Regression test for
+    https://github.com/whitphx/streamlit-webrtc/issues/2405:
+    AudioSourceTrack used a hard-coded 1/48000 time_base, causing the
+    receiver to play audio at the wrong speed when sample_rate != 48000.
+    """
+    ptime = 0.020
+    samples_per_frame = int(sample_rate * ptime)
+
+    track = AudioSourceTrack(
+        callback=_make_callback(sample_rate, samples_per_frame),
+        sample_rate=sample_rate,
+        ptime=ptime,
+    )
+
+    async def run():
+        frames = []
+        for _ in range(3):
+            frames.append(await track.recv())
+        return frames
+
+    frames = asyncio.run(run())
+
+    assert all(f.time_base == fractions.Fraction(1, sample_rate) for f in frames)
+
+    # frame.pts * frame.time_base should advance by exactly ptime per call.
+    timestamps = [float(f.pts * f.time_base) for f in frames]
+    assert timestamps[0] == pytest.approx(0.0)
+    assert timestamps[1] == pytest.approx(ptime)
+    assert timestamps[2] == pytest.approx(2 * ptime)

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -51,3 +51,9 @@ def test_audio_source_track_time_base_matches_sample_rate(sample_rate: int) -> N
     assert timestamps[0] == pytest.approx(0.0)
     assert timestamps[1] == pytest.approx(ptime)
     assert timestamps[2] == pytest.approx(2 * ptime)
+
+
+@pytest.mark.parametrize("sample_rate", [0, -1])
+def test_audio_source_track_rejects_non_positive_sample_rate(sample_rate: int) -> None:
+    with pytest.raises(ValueError, match="sample_rate"):
+        AudioSourceTrack(callback=_make_callback(48000, 960), sample_rate=sample_rate)


### PR DESCRIPTION
## Summary

- `AudioSourceTrack` (and its factory `create_audio_source_track`) hard-coded the outbound `AudioFrame.time_base` to the module-level `AUDIO_TIME_BASE = 1/48000`, so `frame.pts * frame.time_base` no longer matched the actual audio duration when `sample_rate != 48000`. The receiver played audio at the wrong speed (e.g. ~3× faster at `sample_rate=16000`, since `48000 / 16000 = 3`).
- Derive `self._time_base = fractions.Fraction(1, self._sample_rate)` per instance and use it in `recv()`. The pacing logic already used `self._sample_rate`, so no other changes were needed.
- Add a parameterized regression test asserting `frame.pts * frame.time_base` advances by exactly `ptime` per call across several sample rates.

Fixes #2405.

## Test plan

- [x] `uv run pytest tests/source_test.py -v` passes for `sample_rate ∈ {8000, 16000, 44100, 48000}`
- [x] `uv run pytest tests/` (full suite) passes
- [x] `uv run pre-commit run --files streamlit_webrtc/source.py tests/source_test.py changelog.d/*.md` passes (ruff, ruff-format, mypy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio playback speed for non-standard sample rates: audio frame timing is now derived from the configured sample rate and rejects non‑positive sample rates.

* **Tests**
  * Added regression tests validating per-frame timing and time base across multiple sample-rate configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2407)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->