### PR TITLE
fix: hide control buttons when desired_playing_state is set

### DIFF
--- a/changelog.d/20260511_134304_t.yic.yt_hide_stop_button_with_desired_playing_state.md
+++ b/changelog.d/20260511_134304_t.yic.yt_hide_stop_button_with_desired_playing_state.md
@@ -1,0 +1,10 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Fixed
+
+- Hide the Start/Stop and Select Device buttons when `desired_playing_state` is set, since the playing state is controlled programmatically. Previously the Stop button was only disabled but still visible (#2331).

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -62,10 +62,8 @@ function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   }, [stop, clearTakingTooLongTimeout]);
 
   const mode = props.mode;
-  const buttonDisabled =
-    props.disabled ||
-    state.webRtcState === "STOPPING" ||
-    props.desiredPlayingState != null;
+  const userControlsPlayingState = props.desiredPlayingState == null;
+  const buttonDisabled = props.disabled || state.webRtcState === "STOPPING";
   const receivable = isWebRtcMode(mode) && isReceivable(mode);
   const transmittable = isWebRtcMode(mode) && isTransmittable(mode);
   const { videoEnabled, audioEnabled } = getMediaUsage(
@@ -113,39 +111,41 @@ function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
           )
         )}
       </Box>
-      <Box display="flex" justifyContent="space-between">
-        {state.webRtcState === "PLAYING" ||
-        state.webRtcState === "SIGNALLING" ? (
-          <TranslatedButton
-            variant={
-              state.webRtcState === "SIGNALLING" && !isTakingTooLong
-                ? "outlined"
-                : "contained"
-            }
-            onClick={stopWithNotification}
-            disabled={buttonDisabled}
-            translationKey="stop"
-            defaultText="Stop"
-          />
-        ) : (
-          <TranslatedButton
-            variant="contained"
-            color="primary"
-            onClick={startWithNotification}
-            disabled={buttonDisabled}
-            translationKey="start"
-            defaultText="Start"
-          />
-        )}
-        {transmittable && state.webRtcState === "STOPPED" && (
-          <TranslatedButton
-            color="inherit"
-            onClick={openDeviceSelect}
-            translationKey="select_device"
-            defaultText="Select Device"
-          />
-        )}
-      </Box>
+      {userControlsPlayingState && (
+        <Box display="flex" justifyContent="space-between">
+          {state.webRtcState === "PLAYING" ||
+          state.webRtcState === "SIGNALLING" ? (
+            <TranslatedButton
+              variant={
+                state.webRtcState === "SIGNALLING" && !isTakingTooLong
+                  ? "outlined"
+                  : "contained"
+              }
+              onClick={stopWithNotification}
+              disabled={buttonDisabled}
+              translationKey="stop"
+              defaultText="Stop"
+            />
+          ) : (
+            <TranslatedButton
+              variant="contained"
+              color="primary"
+              onClick={startWithNotification}
+              disabled={buttonDisabled}
+              translationKey="start"
+              defaultText="Start"
+            />
+          )}
+          {transmittable && state.webRtcState === "STOPPED" && (
+            <TranslatedButton
+              color="inherit"
+              onClick={openDeviceSelect}
+              translationKey="select_device"
+              defaultText="Select Device"
+            />
+          )}
+        </Box>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- When `desired_playing_state` is set, the playing state is controlled programmatically — the Stop / Start / Select Device buttons no longer serve a purpose.
- Previously the Stop button was only disabled (greyed out) but still visible; now the entire control row is hidden when `desired_playing_state != None`.
- Fixes #2331.

## Test plan
- [x] `tsc -b --noEmit` passes
- [x] `vitest run` — 10/10 tests passing
- [x] `eslint` + `prettier --check` clean
- [ ] Manual: with `desired_playing_state=True`, confirm no Stop button appears
- [ ] Manual: with `desired_playing_state=False`, confirm no Start / Select Device buttons appear
- [ ] Manual: with `desired_playing_state=None` (default), confirm controls behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Start/Stop and Select Device buttons now correctly hide when playback is controlled programmatically, instead of appearing disabled but visible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->