### PR TITLE
ci(test-build): diagnose working-tree state around Build

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -236,8 +236,30 @@ jobs:
       run: pnpm install
       working-directory: streamlit_webrtc/frontend
 
+    - name: Diagnose working-tree state before build
+      run: |
+        echo "::group::git status --short"
+        git status --short
+        echo "::endgroup::"
+        echo "::group::git diff --stat"
+        git diff --stat
+        echo "::endgroup::"
+        echo "::group::git diff (capped)"
+        git diff | head -n 200
+        echo "::endgroup::"
+        echo "::group::git describe"
+        git describe --tags --dirty --always
+        echo "::endgroup::"
+
     - name: Build
       run: make build
+
+    - name: Diagnose working-tree state after build
+      if: always()
+      run: |
+        echo "::group::git status --short"
+        git status --short
+        echo "::endgroup::"
 
     - name: Upload the built artifacts
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Why

The v0.65.2 tag-push build produced a wheel called `streamlit_webrtc-0.65.3.dev0+g23d302a57.d20260512` — hatch-vcs's "dirty at the exact tag" form — and PyPI rejected the upload because `+g…d…` is a local version identifier (not allowed on the index). See [run 25717747713](https://github.com/whitphx/streamlit-webrtc/actions/runs/25717747713/job/75504770875).

Tracing the Build job:

- `actions/checkout` fetched all tags, including `v0.65.2`, and checked out `refs/tags/v0.65.2` (HEAD = `23d302a`). ✓
- During `Install Python dependencies`, uv resolved the local package as `streamlit-webrtc==0.65.2`. ✓
- Something between that step and `make build` left a tracked file modified, because hatch-vcs reports `0.65.3.dev0+g<sha>.d<date>` only when `git describe --dirty` says dirty.

The most likely culprits are the recently-added `./.github/actions/install-safe-chain` and `./.github/actions/setup-takumi-guard` steps (the takumi-guard one writes a registry-proxy config), but we can't tell without seeing the actual list.

## What this PR does

Inserts two diagnostic steps around `Build`:

- **Before:** `git status --short`, `git diff --stat`, first 200 lines of `git diff`, and `git describe --tags --dirty --always`.
- **After (always):** `git status --short` for completeness.

No behavioral change to the build itself.

## Test plan

- [ ] Merge.
- [ ] Wait for the next push to `main` (or a tag push) and look at the new "Diagnose working-tree state before build" group in the `build` job's log.
- [ ] Use the output to either (a) gitignore the offending path or (b) fix the action that's writing into a tracked path.
- [ ] Once fixed, revert this diagnostic PR (or leave the `--short` lines as cheap canaries).

## Related

This is the downstream half of the recovery story for the stuck 0.65.x release chain (see also #2399 / #2400 and the missed-v0.65.1-tag thread). scriv-release v0.3.1's collision-detection now also surfaces a helpful error if a future preview-PR-merge tries to collect a version that already exists in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD diagnostics to capture build environment state before and after the build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2414)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->