### PR TITLE
fix(ci): write Takumi Guard config to a runner-scoped npmrc

### DIFF
--- a/.github/actions/setup-takumi-guard/action.yml
+++ b/.github/actions/setup-takumi-guard/action.yml
@@ -2,10 +2,6 @@ name: Setup Takumi Guard
 description: Configure pnpm to fetch packages through the Takumi Guard registry proxy (anonymous mode).
 
 inputs:
-  working-directory:
-    description: Directory containing the .npmrc to update.
-    required: false
-    default: .
   registry-url:
     description: Takumi Guard proxy registry URL.
     required: false
@@ -14,15 +10,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set Takumi Guard registry in .npmrc
+    - name: Point pnpm at the Takumi Guard registry via a runner-scoped npmrc
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         REGISTRY_URL: ${{ inputs.registry-url }}
       run: |
-        if [ -f .npmrc ]; then
-          grep -v '^registry=' .npmrc > .npmrc.tmp || true
-          mv .npmrc.tmp .npmrc
-        fi
-        echo "registry=${REGISTRY_URL}/" >> .npmrc
-        echo "::notice::Takumi Guard registry set to ${REGISTRY_URL}"
+        npmrc="${RUNNER_TEMP}/takumi-guard-npmrc"
+        echo "registry=${REGISTRY_URL}/" > "$npmrc"
+        echo "NPM_CONFIG_USERCONFIG=${npmrc}" >> "$GITHUB_ENV"
+        echo "::notice::Takumi Guard registry set to ${REGISTRY_URL} (via $npmrc)"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -178,8 +178,6 @@ jobs:
     - uses: ./.github/actions/install-safe-chain
 
     - uses: ./.github/actions/setup-takumi-guard
-      with:
-        working-directory: streamlit_webrtc/frontend
 
     - name: Install dependencies
       run: pnpm install
@@ -229,8 +227,6 @@ jobs:
     - uses: ./.github/actions/install-safe-chain
 
     - uses: ./.github/actions/setup-takumi-guard
-      with:
-        working-directory: streamlit_webrtc/frontend
 
     - name: Install dependencies
       run: pnpm install


### PR DESCRIPTION
## Why

The v0.65.2 tag-push publish ([run 25717747713](https://github.com/whitphx/streamlit-webrtc/actions/runs/25717747713/job/75504770875)) failed because hatch-vcs reported the working tree as dirty during `make build` and produced a wheel called `streamlit_webrtc-0.65.3.dev0+g23d302a57.d20260512` — a *local* version identifier, which PyPI does not accept.

The diagnostic PR (#2414) inserted a `git status --short` before `make build` and showed exactly one dirty path:

```
 M streamlit_webrtc/frontend/.npmrc
```

```
+registry=https://npm.flatt.tech/
```

That comes from `./.github/actions/setup-takumi-guard`, which currently appends the registry line to whatever `.npmrc` is in `working-directory`. The caller passes `streamlit_webrtc/frontend`, but that `.npmrc` is a tracked file with a legitimate `public-hoist-pattern[]=streamlit-component-lib` entry, so every build leaves the tree dirty.

## What this PR does

Move the registry override out of the worktree entirely:

- The action now writes `registry=…/` to `${RUNNER_TEMP}/takumi-guard-npmrc` and exports `NPM_CONFIG_USERCONFIG=<that path>` via `$GITHUB_ENV`.
- pnpm/npm honor `NPM_CONFIG_USERCONFIG` as the user-config-file path, so subsequent `pnpm install` calls pick up the registry override from there.
- The in-repo `streamlit_webrtc/frontend/.npmrc` is no longer touched → working tree stays clean → hatch-vcs reports the actual tag version (`0.65.2`, etc.) and PyPI accepts the upload.

The `working-directory` input is removed from the action (it had no remaining purpose) and the matching `with: working-directory: …` blocks at both call sites in `test-build.yml` go with it.

## Test plan

- [x] CI on this PR — the build job should now report a clean working tree right before `make build` (verifiable in the diagnostic group that #2414 added; or look at the wheel filename in the artifact — it should be `streamlit_webrtc-<sha>-py3-none-any.whl` without `.dev0+…`).
- [ ] Once merged, push the next `v0.65.x` tag and confirm the publish succeeds (`streamlit_webrtc-X.Y.Z.tar.gz`, no `+local` segment).

## Recovery for the still-missed 0.65.2 PyPI upload

This PR fixes future builds but doesn't retroactively publish 0.65.2. Either:

1. Push a tiny no-op commit, cut `v0.65.3` after this lands, and let the action publish that.
2. Or build the v0.65.2 wheel locally on a clean checkout (with this fix applied) and `twine upload` manually.

## Related

- #2414 — diagnostic PR (can be closed once this merges and we don't need the `git status` group anymore; or leave it as a regression canary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline configuration for more reliable dependency management across test and build processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2415)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->