### PR TITLE
chore: add changelog fragment for the takumi-guard CI fix

### DIFF
--- a/changelog.d/20260512_161842_t.yic.yt_chore_fragment_takumi_guard.md
+++ b/changelog.d/20260512_161842_t.yic.yt_chore_fragment_takumi_guard.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Fix the CI release pipeline so tag-push builds no longer leave the working tree dirty during `make build`. `v0.65.2` was tagged but never reached PyPI for this reason; this release supersedes it ([#2415](https://github.com/whitphx/streamlit-webrtc/pull/2415)).


### PR DESCRIPTION
## Summary

Adds a Chore changelog fragment for #2415 so the next push-to-main triggers a Changelog Preview PR for `v0.65.3`. Merging that preview will let the now-clean CI build publish cleanly to PyPI, recovering the release pipeline.

## Context

`v0.65.2` was tagged but never reached PyPI because the takumi-guard step was leaving `streamlit_webrtc/frontend/.npmrc` dirty during `make build`; hatch-vcs produced `0.65.3.dev0+g…d…` which PyPI rejects. #2415 fixed that by writing the registry override to `$RUNNER_TEMP` instead. This release supersedes the missed 0.65.2.

## Test plan

- [ ] Merge.
- [ ] Wait for the scriv-release action to open the "Changelog Preview for Next Release" PR (should be for `0.65.3`).
- [ ] Merge that preview PR.
- [ ] Confirm the scriv-release action tags `v0.65.3`, the tag-push triggers Test and Build with a clean working tree, and Post-build publishes `streamlit_webrtc-0.65.3.tar.gz` to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed CI release pipeline to enable proper publication of releases to PyPI.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2416)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->