### PR TITLE
fix: track ICE candidate dedup IDs per WebRtcWorker instance

### DIFF
--- a/changelog.d/20260512_165053_t.yic.yt_fix_ice_candidate_dedup_per_worker.md
+++ b/changelog.d/20260512_165053_t.yic.yt_fix_ice_candidate_dedup_per_worker.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Track ICE candidate IDs per `WebRtcWorker` instance instead of on the class. The deduplication set was previously a class-level mutable, so a candidate ID seen by one worker could silently suppress `addIceCandidate` calls in any other worker in the same Python process (including across different user sessions).

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -424,6 +424,8 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
         self._relayed_source_video_track: Optional[MediaStreamTrack] = None
         self._relayed_source_audio_track: Optional[MediaStreamTrack] = None
 
+        self._added_ice_candidate_ids: Set[str] = set()
+
         self._session_shutdown_observer: Optional[SessionShutdownObserver] = (
             SessionShutdownObserver(self.stop)
         )
@@ -623,8 +625,6 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
             raise result
 
         return result
-
-    _added_ice_candidate_ids: Set[str] = set()
 
     def set_ice_candidates_from_offerer(self, candidates: Dict[str, Dict]):
         logger.info("Setting ICE candidates from offerer: %s", candidates)


### PR DESCRIPTION
## Summary

`WebRtcWorker._added_ice_candidate_ids` was declared as a class attribute, so the same `set` was shared across every worker instance in the Python process. A candidate ID seen by one worker could silently suppress `addIceCandidate` calls in any other worker — including across different user sessions on a multi-tenant deployment.

Move the initialization into `__init__` so each instance carries its own deduplication set.

```diff
-    _added_ice_candidate_ids: Set[str] = set()
+        # in __init__:
+        self._added_ice_candidate_ids: Set[str] = set()
```

The failure mode is silent — `addIceCandidate` is skipped, no exception is raised — so it can manifest as flaky connectivity that's hard to attribute. No reproducer is included in this PR; a regression test will land with the broader pytest pyramid (see `refactoring/05-add-pytest-layers.md`).

## Test plan

- [x] `uv run pytest` green locally
- [x] `pre-commit run --all-files` green locally
- [ ] CI green

## Refs

`refactoring/03-fix-ice-candidate-mutable-class-attr.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ICE candidates from one connection were incorrectly suppressing candidates in other simultaneous connections within the same application session, improving stability for applications with multiple concurrent WebRTC connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2420)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->