### PR TITLE
docs: add internal refactoring plan

### DIFF
--- a/changelog.d/20260513_042507_t.yic.yt_chore_refactoring_plan.md
+++ b/changelog.d/20260513_042507_t.yic.yt_chore_refactoring_plan.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Add an internal `refactoring/` directory with a long-form code review broken into 8 single-concern work items plus an index. Not part of the published docs site (the `mkdocs.yml` `nav:` is allowlisted) — purely a planning reference for maintainers and coding agents.

--- a/refactoring/01-bump-streamlit-minimum.md
+++ b/refactoring/01-bump-streamlit-minimum.md
@@ -1,0 +1,85 @@
+# 01 — Bump `streamlit` minimum to 1.39.0
+
+## Goal
+
+Drop the minimum Streamlit version from `1.4.0` (Feb 2022) to `1.39.0` (Sep 2024) so the multi-year compatibility layer in `_compat.py` and its callers can be deleted. This is the single biggest reduction in accidental complexity in the codebase.
+
+## Why 1.39.0
+
+| Version | Why it's a candidate |
+|---|---|
+| 1.36.0 | Official `on_change` for components lands. Our `register_callback` hack becomes optional. |
+| **1.39.0** | The `register_callback` hack **stops working** entirely. Anything <1.39.0 forces us to keep the hack — and the only people who use that path are users on Streamlit between 1.36.0–1.38.x, a narrow window. Cleaner to require ≥1.39.0 and delete the hack. |
+
+Latest Streamlit (`develop`) requires `python>=3.10`, identical to us. Bumping ~20 months of Streamlit history off the support floor is reasonable for a major-ish version of `streamlit-webrtc`.
+
+## Edit
+
+`pyproject.toml`:
+
+```toml
+dependencies = [
+    "streamlit>=1.39.0",  # was: 1.4.0
+    ...
+]
+```
+
+## Code to delete entirely
+
+- `streamlit_webrtc/_compat.py` — every `VER_GTE_*` flag and every `try/except ModuleNotFoundError` import-chain. Replace with direct imports from the modern paths:
+  - `from streamlit.runtime.app_session import AppSession, AppSessionState`
+  - `from streamlit.runtime.session_manager import ActiveSessionInfo as SessionInfo`
+  - `from streamlit.runtime.scriptrunner import get_script_run_ctx`
+  - `from streamlit import rerun`
+  - `from streamlit import cache_data`
+- `streamlit_webrtc/server.py` — the `get_current_server()` + `gc.get_objects()` walk only exists for Streamlit <1.14. After the bump, callers can use `Runtime.instance()` directly.
+- `streamlit_webrtc/components_callbacks.py` — the `register_widget` monkey-patch. Real maintenance hazard.
+
+## Code to simplify
+
+- `streamlit_webrtc/eventloop.py` — collapse `get_global_event_loop()` to just:
+  ```python
+  from streamlit.runtime.runtime import Runtime
+  def get_global_event_loop():
+      return Runtime.instance()._get_async_objs().eventloop
+  ```
+  Drop the `tornado.platform.asyncio.BaseAsyncIOLoop` import (only needed for <1.12).
+- `streamlit_webrtc/session_info.py` — collapse `get_this_session_info()` to the `_session_mgr.get_session_info()` branch only. In `get_script_run_count`, drop the `report_run_count` fallback (only needed for <1.6).
+- `streamlit_webrtc/relay.py` — drop both fallback branches; `singleton = Runtime.instance()` is the only one needed.
+- `streamlit_webrtc/component.py`:
+  - Remove the `if not VER_GTE_1_36_0: register_callback(...)` branch. Always use the `on_change` kwarg. Drop the `register_callback` import.
+  - Remove the streamlit==0.84.0 HOTFIX (lines ~533-540, `isinstance(component_value_raw, str)` branch — drop the `json.loads` fallback and `LOGGER.warning("The component value is of type str")`).
+
+## Dev-dep cleanup
+
+`pyproject.toml`, in `[dependency-groups].dev`:
+- Drop `altair<5 ; python_version < '3.11'`.
+- Drop `protobuf<=3.20 ; python_version < '3.11'`.
+
+Both pins exist only to make ancient Streamlit installable on the 3.10 matrix entries.
+
+## CI matrix cleanup
+
+`.github/workflows/test-build.yml` — delete every `include:` entry under the matrix (the rows pinning Streamlit 1.4.0 / 1.6.0 / 1.8.0 / 1.12.0 / 1.12.1 / 1.14.0 / 1.18.0 / 1.27.0 / 1.34.0). Keep the base `python-version` row only.
+
+## Tests to update
+
+- `tests/conftest.py` — the `if ST_VERSION < version.parse("1.55.0")` branch sets `command_line=None`; that's a different version concern (Streamlit 1.55 removed `command_line` from `RuntimeConfig`). Leave that alone in this PR.
+- `tests/session_info_test.py` — `from streamlit_webrtc.server import VER_GTE_1_12_0` will break. Replace the test to always use the `client=Mock()` form. The whole `if VER_GTE_1_12_0` branch can go.
+
+## Acceptance criteria
+
+- `uv run pytest` green.
+- `pre-commit run --all-files` green.
+- `_compat.py`, `server.py`, `components_callbacks.py` no longer exist (or `_compat.py` is reduced to a stub of direct imports only — preference for full deletion and inlining at call sites).
+- CI matrix has no `include:` rows pinning old Streamlit.
+- Changelog fragment under `changelog.d/` documenting the bump.
+
+## Risk notes
+
+- **User-visible breaking change**: users on `streamlit<1.39.0` will have to pin `streamlit-webrtc` to an older version. Call this out in the changelog and consider a minor-version-only bump if the user wants extra caution (note: this project is pre-1.0, so a minor bump is the "breaking" signal).
+- Verify the imports actually exist in 1.39.0 — `streamlit.runtime.runtime.Runtime`, `streamlit.runtime.session_manager.ActiveSessionInfo`, `streamlit.runtime.scriptrunner.get_script_run_ctx`, `streamlit.runtime.app_session.AppSession/AppSessionState`. (They were stable well before 1.39.0, but a sanity check is cheap.)
+
+## Estimated impact
+
+~300 lines of code deleted across 6 files. Zero behavior change for users on Streamlit ≥1.39.0.

--- a/refactoring/02-delete-dead-code.md
+++ b/refactoring/02-delete-dead-code.md
@@ -1,0 +1,88 @@
+# 02 — Delete dead and expired code
+
+## Goal
+
+Remove code paths that are demonstrably dead, expired by their own deprecation notice, or working around bugs in versions no longer supported.
+
+Each bullet is independently shippable. Group them into one PR or split — your call.
+
+## 2.1 — `_test()` block at end of `webrtc.py`
+
+**File**: `streamlit_webrtc/webrtc.py:776-826`
+
+```python
+def _test():
+    ...
+
+if __name__ == "__main__":
+    ...
+    _test()
+```
+
+This is dead. `_test()` calls `WebRtcWorker(mode=WebRtcMode.SENDRECV)` but the current `__init__` requires ~20 positional/keyword args — the call doesn't even import-check. It is not invoked from any test runner; only from the `__main__` block.
+
+**Action**: delete both functions and the `__main__` guard. The replacement is in [05-add-pytest-layers.md](./05-add-pytest-layers.md). (Item 05 doesn't have to land in the same PR — this code is broken-as-is.)
+
+## 2.2 — `video_transformer_factory` / `async_transform` deprecated kwargs
+
+**File**: `streamlit_webrtc/component.py:443-460` (the body) plus the kwargs in each `@overload` and the main signature.
+
+These have been deprecated since v0.20 (years ago). They emit `DeprecationWarning` and forward to the modern names.
+
+**Action**: remove the kwargs entirely from all 4 `@overload`s and the main definition. Remove the forwarding `if` block. Drop the `import warnings` if no longer used. Add a changelog fragment under `Removed`.
+
+**Risk**: any user still passing `video_transformer_factory=...` will get a `TypeError`. Acceptable for a major-ish bump (pre-1.0 minor). If you'd rather not break them, leave for a later, intentional cleanup pass.
+
+## 2.3 — JSON-string HOTFIX for streamlit==0.84.0
+
+**File**: `streamlit_webrtc/component.py:532-540`
+
+```python
+# HOTFIX: The return value from _component_func()
+#         is of type str with streamlit==0.84.0.
+# See https://github.com/whitphx/streamlit-webrtc/issues/287
+component_value: Union[Dict, None]
+if isinstance(component_value_raw, str):
+    LOGGER.warning("The component value is of type str")
+    component_value = json.loads(component_value_raw)
+else:
+    component_value = component_value_raw
+```
+
+Streamlit 0.84.0 is way below the new floor. Folds away after item 01.
+
+**Action**: replace with `component_value: Union[Dict, None] = component_value_raw`. Drop the `import json` if it becomes unused (it's still used a few lines below for `json.dumps`, so leave it).
+
+## 2.4 — `process.py:127` always-truthy `if`
+
+**File**: `streamlit_webrtc/process.py:117-129`
+
+```python
+async def _fallback_recv_queued(self, frames: List[FrameT]) -> List[FrameT]:
+    if len(frames) > 1:
+        logger.warning(...)
+    if self.processor.recv:        # ← always truthy (bound method)
+        return [self.processor.recv(frames[-1])]
+    return [frames[-1]]            # ← dead branch
+```
+
+`self.processor.recv` is always a bound method (defined on `ProcessorBase`). The `if` is always true; the fallback `return [frames[-1]]` is unreachable.
+
+**Action**: drop the `if` and the dead `return`. Just `return [self.processor.recv(frames[-1])]`.
+
+## 2.5 — `from streamlit_webrtc.server import VER_GTE_1_12_0` in tests
+
+**File**: `tests/session_info_test.py:3`
+
+This will break after item 01 deletes `server.py`. If item 01 isn't landing soon, fix here too: the test branches on `VER_GTE_1_12_0` (always true for any supported Streamlit), so collapse to one path.
+
+## Acceptance criteria
+
+- `uv run pytest` green.
+- `pre-commit run --all-files` green.
+- Changelog fragment for 2.2 (user-visible removal). Other items don't need fragments.
+
+## Risk notes
+
+- 2.2 is a user-visible breaking change. Bundle with item 01 if shipping together to amortize the breakage in one release.
+- 2.1, 2.3, 2.4, 2.5 are non-breaking.

--- a/refactoring/03-fix-ice-candidate-mutable-class-attr.md
+++ b/refactoring/03-fix-ice-candidate-mutable-class-attr.md
@@ -1,0 +1,77 @@
+# 03 — Fix `_added_ice_candidate_ids` class-level mutable
+
+## Goal
+
+Fix a latent correctness bug: `WebRtcWorker._added_ice_candidate_ids` is declared as a class attribute, so it is shared across every `WebRtcWorker` instance in the process. ICE candidate IDs from one session can suppress add attempts in a re-created session, including across different users on a multi-tenant deployment.
+
+## Current code
+
+**File**: `streamlit_webrtc/webrtc.py:627`
+
+```python
+class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
+    ...
+    _added_ice_candidate_ids: Set[str] = set()   # ← class-level shared mutable
+
+    def set_ice_candidates_from_offerer(self, candidates: Dict[str, Dict]):
+        ...
+        for candidate_id, candidate_dict in candidates.items():
+            if candidate_id in self._added_ice_candidate_ids:
+                continue
+            ...
+            self._added_ice_candidate_ids.add(candidate_id)
+```
+
+## Fix
+
+Move the initialisation into `__init__`:
+
+```python
+def __init__(self, ...):
+    ...
+    self._added_ice_candidate_ids: Set[str] = set()
+```
+
+And delete the class-level declaration on line 627.
+
+## Why this matters
+
+Candidate IDs are produced by the frontend per session, so collisions across sessions are *probably* rare but not impossible — and the failure mode (silently skipping `addIceCandidate`) is hard to diagnose. The fix is one-line and doesn't need explanation in user-facing docs.
+
+## Test to add
+
+Lightweight: instantiate two workers, simulate adding the same candidate ID to both, assert both actually call through. Can be a unit test that doesn't need a real `RTCPeerConnection` — mock `add_ice_candidate` and `candidate_from_sdp`.
+
+Sketch:
+
+```python
+def test_each_worker_tracks_its_own_added_candidate_ids(monkeypatch):
+    monkeypatch.setattr(
+        "streamlit_webrtc.webrtc.candidate_from_sdp",
+        lambda sdp: object(),
+    )
+    w1 = make_worker_without_starting()
+    w2 = make_worker_without_starting()
+    calls1, calls2 = [], []
+    w1.add_ice_candidate = lambda c: calls1.append(c)
+    w2.add_ice_candidate = lambda c: calls2.append(c)
+    cand = {"id1": {"candidate": "candidate:...", "sdpMid": "0", "sdpMLineIndex": 0}}
+    w1.set_ice_candidates_from_offerer(cand)
+    w2.set_ice_candidates_from_offerer(cand)
+    assert len(calls1) == 1
+    assert len(calls2) == 1  # would be 0 with the bug
+```
+
+`make_worker_without_starting()` may need a helper that bypasses the `RTCPeerConnection`-touching parts of `__init__`. If that's awkward, ship the fix without the test and pick up coverage in item 05.
+
+## Acceptance criteria
+
+- `_added_ice_candidate_ids` initialised per-instance in `__init__`.
+- Class-level attribute deleted.
+- Existing tests still pass.
+- (Optional) regression test added.
+
+## Risk notes
+
+- Pure bugfix, no API change. No changelog fragment needed unless you want to flag it under `Fixed`.
+- Independent of every other item — can ship alone.

--- a/refactoring/04-decouple-worker-from-streamlit-runtime.md
+++ b/refactoring/04-decouple-worker-from-streamlit-runtime.md
@@ -1,0 +1,76 @@
+# 04 — Decouple `WebRtcWorker` from the Streamlit runtime
+
+## Goal
+
+Make `WebRtcWorker` constructable in a pytest process *without* a Streamlit `Runtime.instance()` being present. This is the unlock for the unit/integration tests in item 05.
+
+## Current coupling points
+
+Inside `WebRtcWorker.__init__` and its descendant calls:
+
+1. `streamlit_webrtc/webrtc.py:388` — `loop_context(get_global_event_loop())` reaches into `Runtime.instance()`.
+2. `streamlit_webrtc/webrtc.py:454, 520` — `get_global_event_loop()` and `get_global_relay()` inside `_process_offer_thread_impl`.
+3. `streamlit_webrtc/webrtc.py:653` — `get_global_event_loop()` inside `add_ice_candidate`.
+4. `streamlit_webrtc/webrtc.py:764` — `get_global_event_loop()` inside `stop`.
+5. `streamlit_webrtc/webrtc.py:427-429` — `SessionShutdownObserver(self.stop)` reaches into `get_this_session_info()`, which reaches into `Runtime.instance()`.
+
+## Design
+
+Accept the event loop and relay as constructor arguments. Default them to `None` and resolve from Streamlit lazily, so the public API doesn't change for existing users:
+
+```python
+class WebRtcWorker(Generic[...]):
+    def __init__(
+        self,
+        mode: WebRtcMode,
+        ...,
+        # NEW — keyword-only, defaults to Streamlit-resolved
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        relay: Optional[MediaRelay] = None,
+        session_shutdown_observer_factory: Optional[
+            Callable[[Callable[[], None]], "SessionShutdownObserver"]
+        ] = None,
+    ) -> None:
+        self._loop = loop or get_global_event_loop()
+        self._relay = relay or get_global_relay()
+        ...
+        if session_shutdown_observer_factory is None:
+            self._session_shutdown_observer = SessionShutdownObserver(self.stop)
+        else:
+            self._session_shutdown_observer = session_shutdown_observer_factory(self.stop)
+```
+
+Then replace every `get_global_event_loop()` call inside the worker with `self._loop`, and every `get_global_relay()` with `self._relay`. The Streamlit-runtime hop happens *once*, at construction.
+
+For tests: pass `loop=asyncio.new_event_loop()`, `relay=MediaRelay()`, and a no-op `session_shutdown_observer_factory=lambda cb: _NoopObserver()`.
+
+## Rules
+
+- **Keyword-only.** Don't make these positional. Existing call sites in `component.py` continue to work without changes.
+- **Streamlit code path unchanged.** When `loop=None` and `relay=None`, behavior matches today exactly.
+- **Don't expose `_loop`/`_relay` as public attributes** unless you actually want them on the public API. Underscore-prefix them.
+- `session_shutdown_observer_factory` is the awkward one — `SessionShutdownObserver.__init__` itself calls `get_this_session_info()`. The factory injection lets tests replace it with a no-op observer. If you'd rather not add the third parameter, an alternative is to make `SessionShutdownObserver` no-op gracefully when no session can be resolved (it kind of already does — `if session_info:` is the guard — confirm and document).
+
+## Caveat: `loop_context` usage
+
+`webrtc.py:388-389` uses `loop_context(get_global_event_loop())` to construct an `asyncio.Event` bound to the right loop. After the change this becomes `loop_context(self._loop)` — same effect.
+
+`relay.py:23-26` creates the `MediaRelay` inside `loop_context(loop)`. After injection, if the caller supplies their own `MediaRelay`, they're responsible for having created it on the right loop. Document this in a docstring for the new `relay=` kwarg.
+
+## Tests to keep green
+
+- `tests/import_test.py` — must keep passing.
+- `tests/source_test.py` — unrelated, must keep passing.
+- `tests/session_info_test.py` — unrelated, must keep passing.
+
+## Acceptance criteria
+
+- `WebRtcWorker(...)` can be constructed with explicit `loop=` and `relay=` kwargs.
+- No `get_global_event_loop()` or `get_global_relay()` call inside `WebRtcWorker` methods after construction (`__init__` is allowed to resolve defaults).
+- No public-API change for `component.py` callers.
+- `uv run pytest` green; `pre-commit run --all-files` green.
+
+## Risk notes
+
+- Medium-risk: touches every method that interacts with the loop. Take care that `asyncio.run_coroutine_threadsafe(coro, loop=...)` always uses `self._loop`, never a freshly-resolved one — otherwise tests would silently route across two different loops.
+- Lands cleanly before or after item 01. Easier *after* 01 because the compat shims around `get_global_event_loop` are simpler.

--- a/refactoring/05-add-pytest-layers.md
+++ b/refactoring/05-add-pytest-layers.md
@@ -1,0 +1,134 @@
+# 05 — Add pytest layers for real WebRTC behavior
+
+## Goal
+
+Replace the `_test()` block (deleted in item 02) with a proper test pyramid. The principle: make tests as small as the layer being tested, all the way down to one-frame-through-one-track. The aiortc loopback pattern lets us validate signaling and frame flow without a network.
+
+This work depends on [04-decouple-worker-from-streamlit-runtime.md](./04-decouple-worker-from-streamlit-runtime.md) being done first.
+
+## The four layers
+
+### Layer 1 — Pure functions, no asyncio
+
+Plain pytest. One module per cluster.
+
+| Module under test | What to assert |
+|---|---|
+| `models.CallbackAttachableProcessor` | `recv`, `recv_queued`, `on_ended` call the registered callbacks; `update_callbacks` is thread-safe under the lock; no callback means passthrough |
+| `component.compile_state` | `playing`/`signalling` derived correctly from various component-value shapes |
+| `config.compile_rtc_configuration`, `compile_ice_servers`, `compile_rtc_ice_server` | Valid shapes pass; missing `urls` raises; `None` username/credential survive |
+| `component.generate_frontend_component_key` | Idempotent; collision-resistant for the obvious inputs |
+| `webrtc.WebRtcWorker.set_ice_candidates_from_offerer` (parsing only) | Skips duplicates; tolerates invalid SDP; preserves `sdpMid`/`sdpMLineIndex` |
+
+### Layer 2 — Track unit tests with stub MediaStreamTrack
+
+Same pattern as the existing `tests/source_test.py` (which uses `asyncio.run`). Build a `StubVideoTrack` / `StubAudioTrack` that yields a fixed sequence of frames, hand it to the class under test, drive `recv()` via `asyncio.run`.
+
+| Class under test | What to assert |
+|---|---|
+| `process.VideoProcessTrack` / `AudioProcessTrack` (sync) | One-in-one-out; processor exception propagates; `pts`/`time_base` preserved |
+| `process.AsyncVideoProcessTrack` / `AsyncAudioProcessTrack` | Drops intermediate frames under load (the key invariant of the async path); worker exception surfaces on next `recv()`; `on_ended` fires on stop |
+| `mix.MediaStreamMixTrack` | Mixer callback receives N inputs; output cadence ≈ `mixer_output_interval`; adding/removing input tracks updates the mix |
+| `source.VideoSourceTrack` | pts/time_base correct at video clock rate; warns when callback is too slow (existing audio test covers the audio case) |
+
+### Layer 3 — Loopback integration (the unlock)
+
+This is what `_test()` was reaching for. With item 04 done, the test looks like:
+
+```python
+import asyncio
+from aiortc import RTCPeerConnection
+from aiortc.contrib.media import MediaRelay
+from streamlit_webrtc.webrtc import WebRtcWorker, WebRtcMode
+from streamlit_webrtc.source import VideoSourceTrack
+
+class _NoopShutdownObserver:
+    def stop(self, timeout=1.0): pass
+
+def _noop_observer_factory(_cb):
+    return _NoopShutdownObserver()
+
+async def test_worker_processes_frames_in_sendonly_mode(make_video_frame):
+    loop = asyncio.get_running_loop()
+    relay = MediaRelay()
+
+    client = RTCPeerConnection()
+    client.addTrack(VideoSourceTrack(make_video_frame, fps=10))
+    offer = await client.createOffer()
+    await client.setLocalDescription(offer)
+
+    received: list = []
+    def cb(frame):
+        received.append(frame)
+        return frame
+
+    worker = WebRtcWorker(
+        mode=WebRtcMode.SENDONLY,
+        rtc_configuration=None,
+        ...,
+        video_frame_callback=cb,
+        loop=loop,
+        relay=relay,
+        session_shutdown_observer_factory=_noop_observer_factory,
+    )
+    answer = worker.process_offer(client.localDescription.sdp, client.localDescription.type, timeout=5)
+    await client.setRemoteDescription(answer)
+
+    # Pump frames for a few seconds
+    deadline = loop.time() + 5
+    while loop.time() < deadline and len(received) < 3:
+        await asyncio.sleep(0.1)
+    assert len(received) >= 3
+
+    worker.stop()
+    await client.close()
+```
+
+Cases to cover, one test per case:
+
+| Case | Mode | What to assert |
+|---|---|---|
+| Passthrough video | SENDRECV | Client receives back the same frames it sent (modulo timing) |
+| Processor mutates video | SENDRECV | Client receives the processed frames |
+| Receive-only with source track | RECVONLY | Worker pushes frames from `source_video_track` to client |
+| Audio frame callback | SENDONLY | Audio callback observes frames at the configured ptime |
+| `process_offer` timeout | SENDRECV | `SignallingTimeoutError` raised when the SDP exchange stalls (force by injecting a broken offer) |
+| ICE candidate trickle | SENDRECV | Candidates added before vs after `setRemoteDescription` both work |
+| `update_video_callbacks` mid-flight | SENDRECV | Callback hot-swap takes effect on next frame |
+
+### Layer 4 — Streamlit-level smoke (low priority)
+
+Streamlit's `AppTest` (≥1.24) renders a script and inspects state. Not for frame-level behavior — for the orchestration logic in `webrtc_streamer()` after the split in item 07. Defer until item 07 lands.
+
+## File layout
+
+```
+tests/
+  conftest.py               # existing — keep
+  import_test.py            # existing — keep
+  session_info_test.py      # existing — keep (touched by item 01)
+  source_test.py            # existing — keep
+  config_test.py            # NEW — layer 1
+  models_test.py            # NEW — layer 1 (CallbackAttachableProcessor)
+  component_pure_test.py    # NEW — layer 1 (compile_state, generate_frontend_component_key)
+  process_test.py           # NEW — layer 2
+  mix_test.py               # NEW — layer 2
+  webrtc_loopback_test.py   # NEW — layer 3
+```
+
+## Acceptance criteria
+
+- All four layers exist as separate files (except layer 4, which is optional in this item).
+- `uv run pytest` green on Python 3.10–3.14 in CI.
+- Each new test file runs in <10 seconds in CI (layer 3 may need careful timeouts).
+- The deleted `_test()` block has no resurrection point.
+
+## Risk notes
+
+- Layer 3 is async-heavy and aiortc-loopback is timing-sensitive. Use `pytest-asyncio` (already implicit via `asyncio.run`) and generous timeouts (5s). If tests turn flaky in CI, prefer increasing timeout over disabling.
+- Layer 3 may need `pytest-asyncio` as a dev-dep. Confirm whether the project already has it; if not, add it under `[dependency-groups].dev`.
+- Don't try to test against multiple Streamlit versions in layer 3 — the worker is decoupled from Streamlit by item 04.
+
+## Estimated impact
+
+~600-800 lines of new test code. Real coverage of the previously-untested core.

--- a/refactoring/06-refactor-process-offer-coro.md
+++ b/refactoring/06-refactor-process-offer-coro.md
@@ -1,0 +1,118 @@
+# 06 — Refactor `_process_offer_coro` in `webrtc.py`
+
+## Goal
+
+`_process_offer_coro` is currently 225 lines (`streamlit_webrtc/webrtc.py:92-317`) made up of three large `if mode == ...` branches with substantial duplication. Goal: cut it to roughly 100 lines by extracting two helpers and unifying the per-track logic.
+
+**Do this only after item 05 lands** — without the loopback tests, a behavior-preserving refactor is much harder to verify.
+
+## What's duplicated
+
+Looking across SENDRECV / SENDONLY / RECVONLY:
+
+1. **"Given an input track or a source track and an optional processor, build the output track."** This shape appears five times:
+   - SENDRECV audio (with `source_audio_track` or `audio_processor`)
+   - SENDRECV video (with `source_video_track` or `video_processor`)
+   - SENDONLY audio (only `audio_processor` path)
+   - SENDONLY video (only `video_processor` path)
+   - RECVONLY for both kinds (only `source_*_track` path)
+
+2. **"Wire a track to a recorder via the relay."** Appears 4 times: `in_recorder` for SENDRECV input, `out_recorder` for SENDRECV output, `in_recorder` for SENDONLY input. Each call is `recorder.addTrack(relay.subscribe(track))`.
+
+3. **The `on_track_created` dispatcher**. Same `if track.kind == "video" ... elif "audio"` shape repeated for input and output sides.
+
+## Proposed extractions
+
+### Helper 1: `_build_output_track`
+
+```python
+def _build_output_track(
+    *,
+    kind: Literal["video", "audio"],
+    input_track: Optional[MediaStreamTrack],
+    source_track: Optional[MediaStreamTrack],
+    processor: Optional[ProcessorBase],
+    async_processing: bool,
+    relay: MediaRelay,
+) -> Optional[MediaStreamTrack]:
+    """Return the track that should be sent back / handed to the receiver / recorded.
+
+    Precedence: source_track > processor-wrapped input > raw input > None.
+    Raises if neither input_track nor source_track is provided when a processor exists.
+    """
+```
+
+This single function replaces the inner `if input_track.kind == "audio" / "video"` ladders in `on_track` and the per-transceiver loop in RECVONLY.
+
+### Helper 2: `_notify_track_created`
+
+Trivial — wraps the four-branch dispatcher into one call:
+
+```python
+def _notify_track_created(
+    callback: Callable[[TrackType, MediaStreamTrack], None],
+    role: Literal["input", "output"],
+    track: MediaStreamTrack,
+) -> None:
+    if track.kind == "video":
+        callback(f"{role}:video", track)
+    elif track.kind == "audio":
+        callback(f"{role}:audio", track)
+```
+
+### Mode-specific orchestrators (kept inline or pulled out)
+
+After extraction, each mode branch becomes a clear sequence:
+
+```python
+if mode == WebRtcMode.SENDRECV:
+    @pc.listens_to("track")
+    def on_track(input_track):
+        _notify_track_created(on_track_created, "input", input_track)
+        output_track = _build_output_track(
+            kind=input_track.kind,
+            input_track=input_track,
+            source_track=source_audio_track if input_track.kind == "audio" else source_video_track,
+            processor=audio_processor if input_track.kind == "audio" else video_processor,
+            async_processing=async_processing,
+            relay=relay,
+        )
+        if _should_sendback(output_track.kind, sendback_video, sendback_audio):
+            pc.addTrack(relay.subscribe(output_track))
+        if out_recorder:
+            out_recorder.addTrack(relay.subscribe(output_track))
+        if in_recorder:
+            in_recorder.addTrack(relay.subscribe(input_track))
+        _notify_track_created(on_track_created, "output", output_track)
+        # ...ended handler unchanged
+```
+
+That on_track callback shrinks from ~75 lines to ~15.
+
+## Other tidy-ups in the same PR (optional)
+
+- **Collapse `update_video_callbacks` and `update_audio_callbacks`** (lines 666-714) into one `_update_callbacks(kind, ...)` and two thin public wrappers. Both methods are character-identical apart from attribute names.
+- **Split `_unset_processors`** (lines 716-752) into `_stop_receivers`, `_stop_source_tracks`, `_stop_player`, called in order from `stop()`. Makes the ICE-state-change handler's call easier to follow.
+
+## What to *not* change
+
+- The order of operations inside `on_track` matters for aiortc — keep the original sequence: input notification → output build → addTrack → recorders → output notification → ended handler.
+- The `RECVONLY` branch uses `pc.getTransceivers()` after `setRemoteDescription` — that timing is load-bearing. Don't move it earlier.
+- `remote_description_set_event.set()` placement is load-bearing for `add_ice_candidate`.
+
+## Verification
+
+- Every test from item 05 must pass unchanged.
+- Run the example apps (`home.py`, `pages/*.py`) locally to sanity-check across all three modes. UI-level smoke testing is required because frame flow is hard to assert in unit tests for visual correctness.
+
+## Acceptance criteria
+
+- `_process_offer_coro` reduced to ≤120 lines.
+- `_build_output_track` and `_notify_track_created` extracted with clear docstrings.
+- No behavior change observable in pytest layer 3 or in manual smoke testing.
+- `uv run pytest` green; `pre-commit run --all-files` green.
+
+## Risk notes
+
+- Medium-risk. The refactor preserves order-of-operations that aiortc depends on; getting this wrong produces silent failures (frames don't flow, no exception raised).
+- Strongly prefer landing this *after* item 05 so the loopback test suite catches regressions.

--- a/refactoring/07-refactor-webrtc-streamer-function.md
+++ b/refactoring/07-refactor-webrtc-streamer-function.md
@@ -1,0 +1,101 @@
+# 07 — Refactor the `webrtc_streamer()` function body
+
+## Goal
+
+`webrtc_streamer()` (`streamlit_webrtc/component.py:406-675`) mixes five separable concerns in one ~270-line function. Splitting them into named helpers makes the orchestration loop readable and individually testable.
+
+**Do this after item 05** so layer-4 (`AppTest`) smoke tests can catch regressions.
+
+## The five concerns
+
+| # | Concern | Current line range |
+|---|---|---|
+| 1 | Get-or-create the per-key `WebRtcStreamerContext` in `st.session_state` | 476-498 |
+| 2 | Render the frontend component, including the `on_change` plumbing | 499-531 |
+| 3 | Restore the component value snapshot across `rerun()` | 532-565 |
+| 4 | Worker lifecycle — stop on idle, create on incoming offer, flush SDP answer | 567-657 |
+| 5 | Forward updated callbacks to a running worker | 662-673 |
+
+After extraction, the body looks roughly like:
+
+```python
+def webrtc_streamer(key, mode=..., **kwargs) -> WebRtcStreamerContext:
+    _apply_argument_defaults_and_deprecations(kwargs)
+    context = _get_or_create_context(key)
+    component_value = _render_frontend(key, context, **frontend_kwargs(kwargs))
+    component_value = _restore_snapshot_if_needed(context, component_value)
+    _handle_worker_lifecycle(context, component_value, key, **worker_kwargs(kwargs))
+    _handle_ice_candidates(context, component_value)
+    _update_callbacks(context, **callback_kwargs(kwargs))
+    return context
+```
+
+Total orchestration: ~30 lines.
+
+## Specific extractions
+
+### `_get_or_create_context(key)`
+
+Takes the session-state slot, validates the existing object's type via the `type(...).__name__ == ...` trick (with a comment explaining *why* — it's a real Streamlit hot-reload quirk), creates a fresh `WebRtcStreamerContext` if absent.
+
+### `_render_frontend(key, context, ...)` → component value dict or None
+
+Builds the on-change callback, wires it via `on_change=...` (after item 01 deletes the `register_callback` branch), calls `_component_func(...)`, returns the raw component value.
+
+Sub-helper: `_make_on_change_callback(key, frontend_key, user_on_change)` returns the closure currently inlined at line 501.
+
+### `_restore_snapshot_if_needed(context, component_value)`
+
+The `ComponentValueSnapshot` dance for `rerun()` survivability (lines 542-565). Pure function of inputs and the context's prior snapshot; no Streamlit calls except `get_this_session_info` / `get_script_run_count`.
+
+### `_handle_worker_lifecycle(context, component_value, key, ...)`
+
+Three sub-cases handled in sequence:
+
+1. **Stop**: when not playing and not signalling and a worker exists → stop it, clear SDP, `rerun()`.
+2. **Create**: when no worker but there's an SDP offer → resolve RTC config, instantiate `WebRtcWorker`, call `process_offer`, store on context. Wrap in the existing `context._worker_creation_lock` block.
+3. **Flush answer**: when a worker exists and has a `localDescription` not yet sent → set `context._sdp_answer_json`, `rerun()`.
+
+This is the function that benefits most from splitting; it's also the one with the most subtle threading. Keep the existing comments on `rerun()` placement (lines 652-657) — they encode real bugs the current shape avoids.
+
+### `_handle_ice_candidates(context, component_value)`
+
+One-liner wrapper:
+
+```python
+def _handle_ice_candidates(context, component_value):
+    worker = context._get_worker()
+    if worker and component_value and component_value.get("iceCandidates"):
+        worker.set_ice_candidates_from_offerer(component_value["iceCandidates"])
+```
+
+### `_update_callbacks(context, video_frame_callback=..., ...)`
+
+Wraps lines 662-673. Could even use the consolidated `_update_callbacks` from item 06.
+
+## Type signatures
+
+Keep `webrtc_streamer()`'s overloads exactly as they are — the signature is the public API. Only the body changes.
+
+## What to *not* extract
+
+- The arg-defaulting block (lines 462-474, `if frontend_rtc_configuration is None: ...`) is short and inline-readable. Leaving it is fine.
+- The deprecation warnings block (lines 442-460) goes away entirely after item 02.
+
+## Verification
+
+- All pytest layers from item 05 must pass.
+- Manual smoke: run `home.py` and at least one app from `pages/` end-to-end in each of SENDRECV / SENDONLY / RECVONLY.
+- Verify the `rerun()` workaround for component-value-loss-after-rerun still works: have two `webrtc_streamer()` instances on the same page and trigger a rerun from the first one (this is what the snapshot logic exists for).
+
+## Acceptance criteria
+
+- `webrtc_streamer()` body ≤ 50 lines.
+- Each extracted helper has a one-paragraph docstring describing its concern.
+- No behavior change in tests or in manual smoke testing.
+- `uv run pytest` and `pre-commit` green.
+
+## Risk notes
+
+- Medium-risk. The worker lifecycle has subtle threading interactions (the lock, the `rerun()` placement). Read the inline comments on lines 589, 652-657 carefully before moving anything.
+- This change is purely structural — there should be zero diff in the *behavior* the frontend sees.

--- a/refactoring/08-cleanup-webrtc-streamer-context.md
+++ b/refactoring/08-cleanup-webrtc-streamer-context.md
@@ -1,0 +1,103 @@
+# 08 — Clean up `WebRtcStreamerContext` and the `@overload` chain
+
+## Goal
+
+`WebRtcStreamerContext` has 11 pass-through properties of the same shape, and `webrtc_streamer()` has four `@overload`s × ~45 args each. Goal: reduce duplication without breaking the public API.
+
+This item is independent of items 04-07. Best landed after item 01 (which removes some kwargs from the overload signatures).
+
+## Part A — `WebRtcStreamerContext` pass-through properties
+
+**File**: `streamlit_webrtc/component.py:127-207`
+
+Every property has the same shape:
+
+```python
+@property
+def output_audio_track(self) -> Optional[MediaStreamTrack]:
+    worker = self._get_worker()
+    return worker.output_audio_track if worker else None
+```
+
+11 of them: `video_processor`, `audio_processor`, `video_transformer` (deprecated), `video_receiver`, `audio_receiver`, `source_video_track`, `source_audio_track`, `input_video_track`, `input_audio_track`, `output_video_track`, `output_audio_track`.
+
+### Option A1 — small descriptor (recommended)
+
+```python
+class _WorkerForwarded:
+    def __init__(self, attr): self._attr = attr
+    def __set_name__(self, owner, name): self._attr = self._attr or name
+    def __get__(self, instance, owner=None):
+        if instance is None: return self
+        worker = instance._get_worker()
+        return getattr(worker, self._attr) if worker else None
+
+class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
+    video_processor: Optional[Union[VideoProcessorT, CallbackAttachableProcessor]] = _WorkerForwarded("video_processor")
+    audio_processor: Optional[Union[AudioProcessorT, CallbackAttachableProcessor]] = _WorkerForwarded("audio_processor")
+    video_receiver: Optional[VideoReceiver] = _WorkerForwarded("video_receiver")
+    # ...
+```
+
+Pros: 11 lines instead of ~80. Cons: harder to discover for users via IDE jump-to-definition.
+
+### Option A2 — leave as-is
+
+The properties are tedious but readable. If the goal is "less code, more clarity," option A1 wins. If it's "easier for users to navigate," leave them.
+
+### Option A3 — expose `context.worker` directly
+
+Drop the per-attribute forwarding entirely; tell users to go through `ctx.worker.video_processor` etc. This is *clearer about the lifecycle* (the worker can be `None`) and removes all 11 properties.
+
+Public-API change. Would require a deprecation period: keep the existing properties for one release marked deprecated, add `.worker` property in parallel, remove next major release.
+
+### Recommendation
+
+A1 if you're not ready to break API; A3 if you're willing to do a deprecation cycle. Avoid option A2.
+
+## Part B — `@overload` consolidation
+
+**File**: `streamlit_webrtc/component.py:242-403`
+
+Four overloads, each with ~45 nearly-identical kwargs. The only difference between them is whether `video_processor_factory` and `audio_processor_factory` are typed as `None` or `Optional[...Factory[T]]`. The duplication makes every signature change a five-place edit.
+
+### Option B1 — `TypedDict` + `Unpack` (Python 3.11+)
+
+Define a shared kwargs `TypedDict`, then have each overload extend it with the differing field. Reduces each overload's signature to a few lines.
+
+Requires Python ≥ 3.11 floor. Project currently supports 3.10 (until Oct 2026), so this can't ship until then, *unless* you're OK with `typing_extensions.Unpack`.
+
+### Option B2 — drop overloads entirely
+
+Return type is always `WebRtcStreamerContext[Any, Any]`. Loses the typed narrowing in user code: someone who passes `video_processor_factory=MyVideoProcessor` won't get `ctx.video_processor` typed as `MyVideoProcessor`.
+
+Cost depends on how many users actually rely on this. Likely few. Big win in readability.
+
+### Option B3 — leave as-is
+
+If you change kwargs rarely (which appears to be true — the signature has been stable for a while), the maintenance cost is real but bounded.
+
+### Recommendation
+
+B2 is the largest reduction. B1 is the principled answer but blocked on the Python 3.11 floor. B3 is fine if you don't want to engage with the API question now.
+
+## Part C — Small cleanups in the same area
+
+- `streamlit_webrtc/component.py:212` — the random salt string `r':frontend 6)r])0Gea7e#2E#{y^i*_UzwU"@RJP<z'` works but is alarming. Change to a calm sentinel like `":__webrtc_frontend__"` — under your control on both sides, collisions impossible. Or leave it and add a one-line comment explaining the salt.
+- `streamlit_webrtc/component.py:485` — the `type(context).__name__ != WebRtcStreamerContext.__name__` trick is real (Streamlit hot-reload changes class identity). Add a one-sentence comment so future readers don't try to "fix" it back to `isinstance`.
+- `streamlit_webrtc/component.py:158-167` — `video_transformer` property is deprecated since v0.20. Removable, with a changelog entry under `Removed`. Bundle with item 02's deprecation cleanup if shipping in the same release.
+
+## Acceptance criteria
+
+- Decide A1 vs A3 (or A2 + documented rationale) and apply.
+- Decide B1 vs B2 vs B3 (or B3 + documented rationale) and apply.
+- Salt/sentinel comment landed.
+- Hot-reload trick has a one-line explanatory comment.
+- `uv run pytest` and `pre-commit` green.
+- No mypy regression in `uv run mypy .`.
+
+## Risk notes
+
+- A3 and B2 are public-API changes — they need a changelog fragment and arguably a deprecation cycle.
+- A1 and B1 are pure refactors — no user-visible change.
+- The `__name__` check in `compile_state`-adjacent code looks like a smell but is actually correct; don't "fix" it without understanding Streamlit's script-rerun semantics.

--- a/refactoring/README.md
+++ b/refactoring/README.md
@@ -1,0 +1,23 @@
+# Refactoring plan
+
+Each numbered file is a self-contained unit of work. Order matters: items 1–3 are low-risk preconditions; items 4–5 unlock testability; items 6–8 are the structural cleanup that becomes safe once tests exist.
+
+Pick any one and tell Claude to work on it.
+
+| # | File | Risk | Effort | Depends on |
+|---|---|---|---|---|
+| 1 | [01-bump-streamlit-minimum.md](./01-bump-streamlit-minimum.md) | Low (mechanical) | M | — |
+| 2 | [02-delete-dead-code.md](./02-delete-dead-code.md) | Low | S | — |
+| 3 | [03-fix-ice-candidate-mutable-class-attr.md](./03-fix-ice-candidate-mutable-class-attr.md) | Low | XS | — |
+| 4 | [04-decouple-worker-from-streamlit-runtime.md](./04-decouple-worker-from-streamlit-runtime.md) | Medium | M | 1 (easier after) |
+| 5 | [05-add-pytest-layers.md](./05-add-pytest-layers.md) | Low | M-L | 4 |
+| 6 | [06-refactor-process-offer-coro.md](./06-refactor-process-offer-coro.md) | Medium | M | 5 |
+| 7 | [07-refactor-webrtc-streamer-function.md](./07-refactor-webrtc-streamer-function.md) | Medium | M | 5 |
+| 8 | [08-cleanup-webrtc-streamer-context.md](./08-cleanup-webrtc-streamer-context.md) | Low | S | 1 |
+
+## Cross-cutting principles
+
+- **No public API breakage** unless the doc explicitly says so. `webrtc_streamer()` kwargs, `WebRtcStreamerContext` properties, and the `VideoProcessorBase` / `AudioProcessorBase` contract are part of the contract.
+- **Add a changelog fragment** for any user-visible change.
+- **Each item should land as its own PR.** Don't fold multiple items together — keeping diffs reviewable is the point.
+- **Verify with both `uv run pytest` and `pre-commit run --all-files`** before opening a PR.


### PR DESCRIPTION
## Summary

Captures the long-form code review I did locally as 8 self-contained work items plus an index, under a new `refactoring/` directory. Each item is one PR's worth of work, with goal / current state (file:line refs) / concrete steps / acceptance criteria / risk notes.

| # | Item | Risk | Effort |
|---|---|---|---|
| 1 | Bump `streamlit>=1.39.0` and delete the `_compat` / `server` / `register_callback` layers | Low | M |
| 2 | Delete dead and expired code paths | Low | S |
| 3 | Fix `_added_ice_candidate_ids` class-level mutable | Low | XS |
| 4 | Decouple `WebRtcWorker` from the Streamlit runtime | Med | M |
| 5 | Add a pytest pyramid (pure / track / aiortc loopback / AppTest) | Low | M-L |
| 6 | Refactor `_process_offer_coro` | Med | M |
| 7 | Refactor the `webrtc_streamer()` function body | Med | M |
| 8 | Clean up `WebRtcStreamerContext` and the `@overload` chain | Low | S |

`refactoring/` is **internal-only**: the `mkdocs.yml` `nav:` is allowlisted (`index.md`, `tutorial.md`, `deployment.md`), so this directory won't ship to the published docs site.

Items 2 and 3 are already in flight as #2419 and #2420.

## Test plan

- [ ] CI green (no code change — pure docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a comprehensive refactoring roadmap with eight targeted work items, acceptance criteria, and risk notes to guide staged code cleanup and testing improvements.
* **Documentation**
  * Added detailed refactoring plans and a changelog entry describing planned removals, test reorganization, and other internal maintenance steps to improve reliability and developer workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2421)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->