### PR TITLE
docs(agents): mandate changelog fragments on every PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,15 @@ This file provides guidance for Codex (and other AI agents) working in this repo
 - Full build: `make build`
 - Frontend-only build: `cd streamlit_webrtc/frontend && pnpm run build`
 
-## Release notes
-- Create a changelog fragment with `scriv create` for each PR (`scriv create --edit` to open an editor) and commit it under `changelog.d/`.
-- CI will open a changelog preview PR from committed fragments; maintainers merge it before the automated release build runs.
+## Changelog fragments (required for every PR)
+- **Every PR must include a changelog fragment under `changelog.d/`.** This is mandatory — the release pipeline collects fragments to build the next release's changelog, and a PR without one will not be reflected in the release notes.
+- Create one with `uv run scriv create --edit`. It writes a timestamped file (e.g. `changelog.d/20260513_042424_<user>_<slug>.md`) prefilled with the available categories.
+- Pick **one** category and delete the rest:
+  - `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security` — for user-visible changes.
+  - `Chore` — for internal changes that don't affect users (refactors, dead-code cleanup, tooling, CI, build infra, internal docs).
+- Write a single bullet describing the change. For user-visible categories, write it from the user's perspective; for `Chore`, from the maintainer's. Reference the issue or PR where it adds context.
+- Commit the fragment as part of the same PR — not as a follow-up.
+- CI opens a changelog preview PR from committed fragments; maintainers merge it before the automated release build runs.
 
 ## Contribution notes
 - Keep changes minimal and focused; prefer small, reviewable commits.

--- a/changelog.d/20260513_042742_t.yic.yt_chore_agents_mandate_changelog_fragments.md
+++ b/changelog.d/20260513_042742_t.yic.yt_chore_agents_mandate_changelog_fragments.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Strengthen the changelog-fragments policy in `AGENTS.md` so coding agents always include a fragment when opening a PR, with explicit guidance on which scriv category to pick (`Chore` for internal-only changes).


### PR DESCRIPTION
## Summary

Strengthen the changelog-fragments instruction in `AGENTS.md` so coding agents (Claude, Codex, etc.) reliably add a fragment when opening a PR.

The previous wording was a single bullet under "Release notes" and was easy to overlook. The new "Changelog fragments (required for every PR)" section makes the requirement explicit and tells the agent:

- to run `uv run scriv create --edit`,
- to pick exactly one scriv category,
- to use `Chore` for internal-only changes (refactors, dead-code cleanup, tooling, CI, internal docs),
- to commit the fragment as part of the same PR — not as a follow-up.

This codifies behavior that was already in `CONTRIBUTING.md` ("You should add a fragment for each pull request describing the changes made in the PR") but was easy to miss in the agent-facing entry point.

## Test plan

- [ ] CI green (docs-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contribution guidelines to require changelog fragments in all pull requests, specifying the creation process and categorization requirements for submissions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2422)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->