### PR TITLE
feat: persist input device selection across page reloads

### DIFF
--- a/changelog.d/20260513_201413_t.yic.yt_added_persist_device_selection.md
+++ b/changelog.d/20260513_201413_t.yic.yt_added_persist_device_selection.md
@@ -1,0 +1,3 @@
+### Added
+
+- Remember the selected input devices (camera/microphone) across page reloads. Each `webrtc_streamer(key=...)` keeps its own selection, and a never-configured instance inherits the most recent selection chosen anywhere on the origin. See [#2418](https://github.com/whitphx/streamlit-webrtc/issues/2418).

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -517,6 +517,11 @@ def webrtc_streamer(
         kwargs["on_change"] = callback
     component_value: Union[Dict, None] = _component_func(
         key=frontend_key,
+        # The user-supplied `key` scopes per-instance persistence (e.g.
+        # device selection) in the frontend's localStorage. `frontend_key`
+        # carries an obfuscation suffix that's irrelevant here, so we
+        # forward the original `key` instead.
+        component_key=key,
         sdp_answer_json=context._sdp_answer_json,
         mode=mode.name,
         rtc_configuration=enhance_frontend_rtc_configuration(

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import Box from "@mui/material/Box";
 import DeviceSelectForm from "./DeviceSelect/DeviceSelectForm";
 import MediaStreamPlayer from "./MediaStreamPlayer";
@@ -14,6 +14,7 @@ import {
 import { useTimer } from "./use-timeout";
 import { getMediaUsage } from "./media-constraint";
 import { ComponentValue, setComponentValue } from "./component-value";
+import { loadPersistedDeviceIds, persistDeviceIds } from "./device-storage";
 import TranslatedButton from "./translation/components/TranslatedButton";
 import InfoHeader from "./InfoHeader";
 import "webrtc-adapter";
@@ -23,6 +24,7 @@ const BACKEND_VANILLA_ICE_TIMEOUT = 10 * 1000; // `aiortc` runs ICE in the Vanil
 interface WebRtcStreamerInnerProps {
   disabled: boolean;
   mode: WebRtcMode;
+  componentKey: string | undefined;
   desiredPlayingState: boolean | undefined;
   sdpAnswerJson: string | undefined;
   rtcConfiguration: RTCConfiguration | undefined;
@@ -32,10 +34,20 @@ interface WebRtcStreamerInnerProps {
   onComponentValueChange: (newComponentValue: ComponentValue) => void;
 }
 function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
+  const { componentKey } = props;
   const [deviceIds, setDeviceIds] = useState<{
     video?: MediaDeviceInfo["deviceId"] | undefined;
     audio?: MediaDeviceInfo["deviceId"] | undefined;
-  }>({ video: undefined, audio: undefined });
+  }>(() => loadPersistedDeviceIds(componentKey));
+
+  // Persist whenever the selection changes — both the DeviceSelect form's
+  // `onSelect` and the WebRTC hook's `onDevicesOpened` route through
+  // `setDeviceIds`, so this single effect covers both paths.
+  const initialDeviceIdsRef = useRef(deviceIds);
+  useEffect(() => {
+    if (deviceIds === initialDeviceIdsRef.current) return;
+    persistDeviceIds(componentKey, deviceIds);
+  }, [componentKey, deviceIds]);
   const { state, start, stop } = useWebRtc(
     props,
     deviceIds.video,
@@ -154,6 +166,7 @@ function WebRtcStreamer() {
   const renderData = useRenderData();
 
   const mode = renderData.args["mode"];
+  const componentKey: string | undefined = renderData.args["component_key"];
   const desiredPlayingState = renderData.args["desired_playing_state"];
   const sdpAnswerJson = renderData.args["sdp_answer_json"];
   const rtcConfiguration: RTCConfiguration = renderData.args.rtc_configuration;
@@ -170,6 +183,7 @@ function WebRtcStreamer() {
     <WebRtcStreamerInner
       disabled={renderData.disabled}
       mode={mode}
+      componentKey={componentKey}
       desiredPlayingState={desiredPlayingState}
       sdpAnswerJson={sdpAnswerJson}
       rtcConfiguration={rtcConfiguration}

--- a/streamlit_webrtc/frontend/src/device-storage.test.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadPersistedDeviceIds, persistDeviceIds } from "./device-storage";
+
+const GLOBAL_KEY = "streamlit-webrtc:device-ids";
+const perComponentKey = (k: string) => `streamlit-webrtc:device-ids:${k}`;
+
+describe("device-storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("loadPersistedDeviceIds()", () => {
+    it("returns an empty object when nothing has been stored", () => {
+      expect(loadPersistedDeviceIds("myKey")).toEqual({});
+    });
+
+    it("returns the per-component entry when present", () => {
+      window.localStorage.setItem(
+        perComponentKey("myKey"),
+        JSON.stringify({ video: "vid-A", audio: "aud-A" }),
+      );
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid-B", audio: "aud-B" }),
+      );
+      expect(loadPersistedDeviceIds("myKey")).toEqual({
+        video: "vid-A",
+        audio: "aud-A",
+      });
+    });
+
+    it("falls back to the global entry when no per-component entry exists", () => {
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid-B", audio: "aud-B" }),
+      );
+      expect(loadPersistedDeviceIds("myKey")).toEqual({
+        video: "vid-B",
+        audio: "aud-B",
+      });
+    });
+
+    it("reads only the global entry when no component key is provided", () => {
+      window.localStorage.setItem(
+        perComponentKey("myKey"),
+        JSON.stringify({ video: "vid-A" }),
+      );
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid-B" }),
+      );
+      expect(loadPersistedDeviceIds(undefined)).toEqual({ video: "vid-B" });
+    });
+
+    it("ignores malformed JSON", () => {
+      window.localStorage.setItem(perComponentKey("myKey"), "not json{{");
+      expect(loadPersistedDeviceIds("myKey")).toEqual({});
+    });
+
+    it("ignores non-string fields", () => {
+      window.localStorage.setItem(
+        perComponentKey("myKey"),
+        JSON.stringify({ video: 42, audio: null }),
+      );
+      expect(loadPersistedDeviceIds("myKey")).toEqual({});
+    });
+  });
+
+  describe("persistDeviceIds()", () => {
+    it("writes both per-component and global entries", () => {
+      persistDeviceIds("myKey", { video: "vid", audio: "aud" });
+      expect(JSON.parse(window.localStorage.getItem(GLOBAL_KEY)!)).toEqual({
+        video: "vid",
+        audio: "aud",
+      });
+      expect(
+        JSON.parse(window.localStorage.getItem(perComponentKey("myKey"))!),
+      ).toEqual({ video: "vid", audio: "aud" });
+    });
+
+    it("writes only the global entry when no component key is provided", () => {
+      persistDeviceIds(undefined, { video: "vid" });
+      expect(JSON.parse(window.localStorage.getItem(GLOBAL_KEY)!)).toEqual({
+        video: "vid",
+      });
+    });
+
+    it("does not clobber an existing entry with an empty selection", () => {
+      window.localStorage.setItem(
+        perComponentKey("myKey"),
+        JSON.stringify({ video: "vid", audio: "aud" }),
+      );
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid", audio: "aud" }),
+      );
+      persistDeviceIds("myKey", {});
+      expect(JSON.parse(window.localStorage.getItem(GLOBAL_KEY)!)).toEqual({
+        video: "vid",
+        audio: "aud",
+      });
+      expect(
+        JSON.parse(window.localStorage.getItem(perComponentKey("myKey"))!),
+      ).toEqual({ video: "vid", audio: "aud" });
+    });
+
+    it("swallows storage errors", () => {
+      const setItem = vi
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new Error("QuotaExceededError");
+        });
+      expect(() => persistDeviceIds("myKey", { video: "vid" })).not.toThrow();
+      expect(setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe("round-trip", () => {
+    it("restores what was written when reloading the same component", () => {
+      persistDeviceIds("myKey", { video: "vid-X", audio: "aud-Y" });
+      expect(loadPersistedDeviceIds("myKey")).toEqual({
+        video: "vid-X",
+        audio: "aud-Y",
+      });
+    });
+
+    it("seeds a new component with the most recent global selection", () => {
+      persistDeviceIds("firstComponent", { video: "vid-X", audio: "aud-Y" });
+      expect(loadPersistedDeviceIds("newComponent")).toEqual({
+        video: "vid-X",
+        audio: "aud-Y",
+      });
+    });
+
+    it("keeps per-component selections independent after both have been set", () => {
+      persistDeviceIds("componentA", { video: "vid-A", audio: "aud-A" });
+      persistDeviceIds("componentB", { video: "vid-B", audio: "aud-B" });
+      expect(loadPersistedDeviceIds("componentA")).toEqual({
+        video: "vid-A",
+        audio: "aud-A",
+      });
+      expect(loadPersistedDeviceIds("componentB")).toEqual({
+        video: "vid-B",
+        audio: "aud-B",
+      });
+    });
+  });
+});

--- a/streamlit_webrtc/frontend/src/device-storage.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.ts
@@ -62,7 +62,7 @@ function write(key: string, value: PersistedDeviceIds): void {
 export function loadPersistedDeviceIds(
   componentKey: string | undefined,
 ): PersistedDeviceIds {
-  if (componentKey) {
+  if (componentKey != null) {
     const perComponent = read(PER_COMPONENT_PREFIX + componentKey);
     if (perComponent != null) return perComponent;
   }
@@ -77,7 +77,7 @@ export function persistDeviceIds(
   // selection with `{}` during the brief window before devices are opened.
   if (deviceIds.video == null && deviceIds.audio == null) return;
   write(GLOBAL_KEY, deviceIds);
-  if (componentKey) {
+  if (componentKey != null) {
     write(PER_COMPONENT_PREFIX + componentKey, deviceIds);
   }
 }

--- a/streamlit_webrtc/frontend/src/device-storage.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.ts
@@ -1,0 +1,83 @@
+// Persists the user's input-device selection across page reloads.
+//
+// Two scopes are written on every selection:
+//   - per-component, keyed by the Streamlit component's `key` argument
+//   - global, shared across every webrtc_streamer instance on this origin
+//
+// On load we prefer the per-component entry and fall back to the global one,
+// so a first-time component instance picks up the user's last choice while
+// already-configured instances keep their own.
+
+const GLOBAL_KEY = "streamlit-webrtc:device-ids";
+const PER_COMPONENT_PREFIX = "streamlit-webrtc:device-ids:";
+
+export interface PersistedDeviceIds {
+  video?: MediaDeviceInfo["deviceId"];
+  audio?: MediaDeviceInfo["deviceId"];
+}
+
+function safeLocalStorage(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    // localStorage access can throw in sandboxed iframes or when site data
+    // is blocked.
+    return null;
+  }
+}
+
+function read(key: string): PersistedDeviceIds | null {
+  const storage = safeLocalStorage();
+  if (storage == null) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(key);
+  } catch {
+    return null;
+  }
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed == null || typeof parsed !== "object") return null;
+    const { video, audio } = parsed as Record<string, unknown>;
+    const result: PersistedDeviceIds = {};
+    if (typeof video === "string") result.video = video;
+    if (typeof audio === "string") result.audio = audio;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: PersistedDeviceIds): void {
+  const storage = safeLocalStorage();
+  if (storage == null) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // QuotaExceededError, SecurityError, etc. — persistence is best-effort.
+  }
+}
+
+export function loadPersistedDeviceIds(
+  componentKey: string | undefined,
+): PersistedDeviceIds {
+  if (componentKey) {
+    const perComponent = read(PER_COMPONENT_PREFIX + componentKey);
+    if (perComponent != null) return perComponent;
+  }
+  return read(GLOBAL_KEY) ?? {};
+}
+
+export function persistDeviceIds(
+  componentKey: string | undefined,
+  deviceIds: PersistedDeviceIds,
+): void {
+  // Skip writing an entry with no usable IDs to avoid clobbering an existing
+  // selection with `{}` during the brief window before devices are opened.
+  if (deviceIds.video == null && deviceIds.audio == null) return;
+  write(GLOBAL_KEY, deviceIds);
+  if (componentKey) {
+    write(PER_COMPONENT_PREFIX + componentKey, deviceIds);
+  }
+}


### PR DESCRIPTION
## Summary

- Device selection in the WebRTC streamer now survives page reloads, addressing #2418.
- Per-component persistence: each `webrtc_streamer(key=...)` keeps its own choice.
- Global fallback: a never-configured instance inherits the user's most recent choice from anywhere on the origin.

## Design

`streamlit_webrtc/frontend/src/device-storage.ts` is a small `localStorage` wrapper with two scopes:

- `streamlit-webrtc:device-ids:<componentKey>` — per-component bucket
- `streamlit-webrtc:device-ids` — global bucket

On every save we write to both. On load we prefer the per-component bucket and fall back to global. Storage errors are swallowed (sandboxed iframes, blocked storage, quota issues).

`WebRtcStreamer.tsx` seeds the existing `deviceIds` `useState` from storage and persists on change via a single `useEffect`. Both write paths in the app — `DeviceSelect.onSelect` and `useWebRtc.onDevicesOpened` — already route through `setDeviceIds`, so the one effect covers both.

`component.py` forwards the user-supplied `key` to the frontend as `component_key` so the per-component bucket has a stable identifier. The existing `frontend_key` carries a session-state collision suffix that's irrelevant for localStorage scoping.

Stale device IDs are safe: `compileMediaConstraints` uses `{ deviceId: id }` (ideal, not exact), so `getUserMedia` falls back gracefully if a remembered device is gone. `DeviceSelect.ensureValidSelection` also re-validates against `enumerateDevices()`.

No changes to the public API.

## Test plan

- [x] `pnpm test -- --run` — 3 files / 23 tests passed (12 new tests in `device-storage.test.ts`)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `uv run pytest` — 8 passed
- [x] `uv run pre-commit run --all-files` — ruff / ruff-format / mypy all passed
- [ ] Manual: with `_RELEASE = False`, open the app, pick a non-default camera/mic, reload, confirm the selection persists.
- [ ] Manual: pick devices in two `webrtc_streamer` instances with different `key`s, reload, confirm each remembers its own.
- [ ] Manual: add a brand-new `webrtc_streamer(key=...)`, confirm it picks up the global default on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Camera and microphone selections persist across page reloads—each instance keeps its own device preferences, while unconfigured instances inherit the most recent choice.
* **Bug Fixes / Reliability**
  * Improved robustness when storing/loading device selections to handle restricted environments and malformed data without disrupting the app.
* **Tests**
  * Added tests to verify persistence, fallback behavior, and resilience to storage errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2426)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->