### PR TITLE
chore: bump whitphx/scriv-release v0.3.0 -> v0.4.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,8 +29,8 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@31da80e50064bc5f9d3f631f51264c532fa18747 # v0.3.0
+        uses: whitphx/scriv-release@dc596bb677b1a66a2a7c8f8e913872e2cf894afd # v0.4.0
         with:
-          app-id: ${{ vars.MY_CHANGESETS_APP_ID }}
+          client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}
           preview-branch: scriv-preview

--- a/changelog.d/20260515_100330_t.yic.yt_chore_bump_scriv_release.md
+++ b/changelog.d/20260515_100330_t.yic.yt_chore_bump_scriv_release.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.3.0 to v0.4.0, which renamed the `app-id` input to `client-id` (the GitHub App's Client ID, not its App ID).


### PR DESCRIPTION
## Summary

- Bumps the `whitphx/scriv-release` GitHub Action from v0.3.0 to v0.4.0.
- Renames the action input `app-id` → `client-id` (breaking change in v0.4.0; the value is now forwarded to `actions/create-github-app-token` as a GitHub App **Client ID**, which is different from the App ID).
- Updates the workflow to reference a new repo variable `MY_CHANGESETS_APP_CLIENT_ID`.

## Required repo-config change before merge

The workflow will fail until the repo has a variable named `MY_CHANGESETS_APP_CLIENT_ID` containing the GitHub App's **Client ID** (found on the App's settings page, separate from "App ID"). The old `MY_CHANGESETS_APP_ID` variable can be removed afterward.

## Test plan

- [ ] Add `MY_CHANGESETS_APP_CLIENT_ID` repo variable with the App's Client ID.
- [ ] Confirm a push to `main` that includes a changelog fragment opens/updates the scriv-preview PR via the new action version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub Actions workflow for automated changelog and release management with a newer version of the automation service, improving overall reliability.
  * Refined workflow configuration to ensure better compatibility and optimal performance in the release automation pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2431)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->