### PR TITLE
chore: burn 0.67.0 after PyPI mis-publish

### DIFF
--- a/changelog.d/20260515_145451_t.yic.yt_chore_burn_0_67_0.md
+++ b/changelog.d/20260515_145451_t.yic.yt_chore_burn_0_67_0.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Burn version `0.67.0`. During the `v0.66.0` release on 2026-05-15 a stray `v0.67.0` git tag caused `hatch-vcs` to label the v0.66.0 wheel as `0.67.0`, which then got published to PyPI. The PyPI release `0.67.0` is yanked; the git tag `v0.67.0` is now a permanent placeholder pointing at the `v0.66.1` commit so the release pipeline skips `0.67.0` and advances to `0.68.0` on the next minor bump.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected a version numbering error where 0.67.0 was accidentally published to PyPI during the 0.66.0 release cycle and has been removed. The versioning has been adjusted so future releases will proceed directly to 0.68.0, skipping 0.67.0 entirely.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->