### PR TITLE
chore: bump whitphx/scriv-release v0.4.0 -> v0.5.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@dc596bb677b1a66a2a7c8f8e913872e2cf894afd # v0.4.0
+        uses: whitphx/scriv-release@881ad24f6f65d532b375fbabd7477254e1500d04 # v0.5.0
         with:
           client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}

--- a/changelog.d/20260515_223543_t.yic.yt_chore_bump_scriv_release_0_5_0.md
+++ b/changelog.d/20260515_223543_t.yic.yt_chore_bump_scriv_release_0_5_0.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.4.0 to v0.5.0. The action's release flow now bundles the version-file bump into the Changelog Preview PR itself (so the merge commit carries both the new CHANGELOG entry and the pyproject.toml bump in a single commit), and it aborts with a clear error when the version provider's reported current version disagrees with the most recent CHANGELOG.md entry — catching the kind of orphan/stale tag drift that produced the v0.67.0 mishap.


### PR DESCRIPTION
## Summary

- Bump the `whitphx/scriv-release` action from [v0.4.0](https://github.com/whitphx/scriv-release/releases/tag/v0.4.0) to [v0.5.0](https://github.com/whitphx/scriv-release/releases/tag/v0.5.0).
- v0.5.0 moves the version-file bump into the **Changelog Preview PR** itself, so the merge commit carries both the new CHANGELOG entry and any pyproject.toml/equivalent bump in a single commit (and the subsequent tag lands on that commit). Not user-visible in streamlit-webrtc's release flow today since the version is `dynamic` via hatch-vcs, but it makes the action behave more predictably.
- v0.5.0 also adds a sanity check that aborts the release flow when the version provider's reported current version disagrees with the most recent CHANGELOG.md entry — catching the kind of orphan/stale-tag drift that produced the v0.67.0 mishap.

## Test plan

- [ ] Action runs on the merge of this PR without errors and either no-ops (no fragments at HEAD) or opens/updates the Changelog Preview PR as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated changelog automation tooling to improve the release process with enhanced version tracking and conflict detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->