### PR TITLE
chore: bump whitphx/scriv-release v0.5.0 -> v0.5.1

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@881ad24f6f65d532b375fbabd7477254e1500d04 # v0.5.0
+        uses: whitphx/scriv-release@e427d7449808f7698d81183910a0b81cd6166bf1 # v0.5.1
         with:
           client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}

--- a/changelog.d/20260515_225319_t.yic.yt_chore_bump_scriv_release_0_5_1.md
+++ b/changelog.d/20260515_225319_t.yic.yt_chore_bump_scriv_release_0_5_1.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.5.0 to v0.5.1, which fixes a regression v0.5.0 introduced: the new "bump version files in the preview PR" step crashed with `Git working directory is not clean` because `bump-my-version` was invoked right after `scriv collect` (which leaves CHANGELOG.md modified and the fragment deleted). v0.5.1 passes `--allow-dirty` so the bump tool tolerates that intentional in-progress state.


### PR DESCRIPTION
## Summary

- Bump the `whitphx/scriv-release` action from [v0.5.0](https://github.com/whitphx/scriv-release/releases/tag/v0.5.0) to [v0.5.1](https://github.com/whitphx/scriv-release/releases/tag/v0.5.1).
- v0.5.1 fixes a regression v0.5.0 introduced: the new "bump version files in the preview PR" step crashed with `Git working directory is not clean` because the `bump-my-version` provider was invoked right after `scriv collect` (which modifies `CHANGELOG.md` and deletes the consumed fragment) without `--allow-dirty`. v0.5.1 passes the flag.
- The post-merge changelog workflow on #2436 (the v0.5.0 bump) hit this bug — see [run 25944882168](https://github.com/whitphx/streamlit-webrtc/actions/runs/25944882168). Merging this unblocks the release workflow.

## Test plan

- [ ] Action runs on the merge of this PR without errors and either no-ops (no fragments at HEAD) or opens/updates the Changelog Preview PR cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the scriv-release GitHub Action to v0.5.1, resolving a regression affecting the automated release and version bumping workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->