### PR TITLE
chore: bump whitphx/scriv-release v0.6.0 -> v0.6.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@1d90039a985bb083336f56bf4987512b021ce108 # v0.6.0
+        uses: whitphx/scriv-release@491e72621f7706dc2896354b9ab04c15e9879c20 # v0.6.2
         with:
           client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}

--- a/changelog.d/20260516_011312_t.yic.yt_chore_bump_scriv_release_0_6_2.md
+++ b/changelog.d/20260516_011312_t.yic.yt_chore_bump_scriv_release_0_6_2.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.6.0 to v0.6.2. v0.6.1 expands the drift-guard error message to also show the correct `git tag -a v{version} <commit>` recovery hint when the latest tag is *behind* the latest CHANGELOG entry (the shape we hit during the v0.5.x → v0.6.0 transition that required manually tagging v0.67.2). v0.6.2 switches scriv-release's own packaging to `hatch-vcs`-driven dynamic versioning — internal-only, no behavior change for this project.


### PR DESCRIPTION
## Summary

- Bump `whitphx/scriv-release` from [v0.6.0](https://github.com/whitphx/scriv-release/releases/tag/v0.6.0) to [v0.6.2](https://github.com/whitphx/scriv-release/releases/tag/v0.6.2).
- **v0.6.1** expands the drift-guard error to also show the correct `git tag -a v{version} <commit>` recovery hint when the latest tag is *behind* the latest CHANGELOG entry — the exact shape we hit during the v0.5.x → v0.6.0 transition that required manually tagging v0.67.2.
- **v0.6.2** is an internal-only change to scriv-release's own packaging (switch to hatch-vcs-driven dynamic versioning); no behavior change for this project.

## Test plan

- [ ] Workflow on this PR's merge opens/updates the Changelog Preview PR cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling used for changelog generation to improve error handling and packaging consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->