### PR TITLE
chore: bump whitphx/scriv-release v0.6.2 -> v0.6.3

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@491e72621f7706dc2896354b9ab04c15e9879c20 # v0.6.2
+        uses: whitphx/scriv-release@09e7d274caf0c1bdc6fd9637e4b0922d12e83be3 # v0.6.3
         with:
           client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}

--- a/changelog.d/20260516_013236_t.yic.yt_chore_bump_scriv_release_0_6_3.md
+++ b/changelog.d/20260516_013236_t.yic.yt_chore_bump_scriv_release_0_6_3.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.6.2 to v0.6.3. v0.6.3 fixes a regression v0.6.2 introduced: the action's `pip install` step crashed with `setuptools-scm was unable to detect version` because v0.6.2 switched scriv-release's own packaging to `hatch-vcs` but GitHub Actions checks out the action source without a `.git` directory, so hatch-vcs had nothing to compute a version from. v0.6.3 sets a `fallback-version` so the install succeeds — see action run 25949017805 on this repo for the original crash.


### PR DESCRIPTION
## Summary

- Bump `whitphx/scriv-release` from [v0.6.2](https://github.com/whitphx/scriv-release/releases/tag/v0.6.2) to [v0.6.3](https://github.com/whitphx/scriv-release/releases/tag/v0.6.3).
- v0.6.3 fixes the regression v0.6.2 introduced: the action's `pip install` step crashed with `setuptools-scm was unable to detect version` because v0.6.2 switched scriv-release's own packaging to `hatch-vcs`, but GitHub Actions checks out action source without a `.git` directory, so hatch-vcs had nothing to compute a version from. v0.6.3 sets a `fallback-version` so the install just succeeds.
- See [action run 25949017805](https://github.com/whitphx/streamlit-webrtc/actions/runs/25949017805) on this repo for the original crash (the workflow that ran after #2440 merged).

## Test plan

- [ ] Workflow on this PR's merge runs to completion without the `setuptools-scm was unable to detect version` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to use a newer version of the GitHub Action that resolves a regression preventing potential failures during the dependency installation step in the CI pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->