### PR TITLE
chore: bump whitphx/scriv-release v0.6.3 -> v0.7.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Run scriv-release
-        uses: whitphx/scriv-release@09e7d274caf0c1bdc6fd9637e4b0922d12e83be3 # v0.6.3
+        uses: whitphx/scriv-release@591fbdc73d28e1fc559c92ead1e227f7aa05b2fa # v0.7.0
         with:
           client-id: ${{ vars.MY_CHANGESETS_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.MY_CHANGESETS_APP_PRIVATE_KEY }}

--- a/changelog.d/20260516_015258_t.yic.yt_chore_bump_scriv_release_0_7_0.md
+++ b/changelog.d/20260516_015258_t.yic.yt_chore_bump_scriv_release_0_7_0.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Bump the `whitphx/scriv-release` GitHub Action from v0.6.3 to v0.7.0. v0.7.0 re-introduces the "bump version files in the Changelog Preview PR" behavior — for file-based providers the preview-PR commit captures both the new CHANGELOG entry and the version-file bump in a single commit; for tag-only providers (this project, via `bump-my-version` + `hatch-vcs`) it remains a no-op. The release-time bug from the previous attempt (v0.5.x crashed with `fatal: tag 'vX.Y.Z' already exists` for tag-only providers) is fixed by reading the version to tag from the latest `CHANGELOG.md` entry rather than from `provider.current()`, so both provider styles converge on the right tag.


### PR DESCRIPTION
## Summary

- Bump `whitphx/scriv-release` from [v0.6.3](https://github.com/whitphx/scriv-release/releases/tag/v0.6.3) to [v0.7.0](https://github.com/whitphx/scriv-release/releases/tag/v0.7.0).
- **v0.7.0** re-introduces the "bump version files in the Changelog Preview PR" behavior. For *file-based* providers (uv with a static `[project].version`, bump-my-version with `[tool.bumpversion]`, hatch with a non-`vcs` source, shell) the preview-PR commit captures both the new `CHANGELOG.md` entry and the version-file bump in a single commit. For *tag-only* providers (this project, via `bump-my-version` + `hatch-vcs`) it's a no-op — there's no file to bump.
- The release-time bug from the previous attempt (v0.5.x crashed with `fatal: tag 'vX.Y.Z' already exists` for tag-only providers, which is what brought down our release flow last time) is fixed by reading the version to tag from the latest `CHANGELOG.md` entry rather than from `provider.current()`. Both provider styles now converge on the right tag.

## Test plan

- [ ] Workflow on this PR's merge opens/updates the Changelog Preview PR (currently scriv-preview / #2442) cleanly.
- [ ] After merging the next preview PR, the new tag is pushed without `fatal: tag '...' already exists`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation tooling to improve changelog and version management during the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->