### PR TITLE
refactor: drop deprecated video_transformer_factory and async_transform kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ The API is not finalized yet and can be changed without backward compatibility i
 `VideoTransformerBase` and its `transform` method have been marked as deprecated in v0.20.0. Please use `VideoProcessorBase#recv()` instead.
 Note that the signature of the `recv` method is different from the `transform` in that the `recv` has to return an instance of `av.VideoFrame` or `av.AudioFrame`.
 
-Also, `webrtc_streamer()`'s `video_transformer_factory` and `async_transform` arguments are deprecated, so use `video_processor_factory` and `async_processing` respectively.
+Also, `webrtc_streamer()`'s `video_transformer_factory` and `async_transform` arguments — deprecated since v0.20 — have been removed. Use `video_processor_factory` and `async_processing` respectively.
 
 See the samples in [app.py](./app.py) for their usage.
 

--- a/changelog.d/20260515_191109_t.yic.yt_drop_deprecated_kwargs.md
+++ b/changelog.d/20260515_191109_t.yic.yt_drop_deprecated_kwargs.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Drop the long-deprecated `video_transformer_factory` and `async_transform` arguments of `webrtc_streamer()`. They have been raising `DeprecationWarning` since v0.20 (released 2021) — use `video_processor_factory` and `async_processing` instead. Passing the old names now raises `TypeError`.

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import threading
-import warnings
 import weakref
 from typing import (
     Any,
@@ -156,11 +155,10 @@ class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
     @property
     def video_transformer(self) -> Optional[VideoProcessorT]:
         """
-        A video transformer instance which has been created through
-        the callable provided as `video_transformer_factory` argument
-        to `webrtc_streamer()`.
+        Alias of :py:attr:`video_processor`.
 
         .. deprecated:: 0.20.0
+            Use :py:attr:`video_processor` instead.
         """
         worker = self._get_worker()
         return cast(VideoProcessorT, worker.video_processor) if worker else None
@@ -271,9 +269,6 @@ def webrtc_streamer(
     audio_html_attrs: Optional[Union[AudioHTMLAttributes, Dict]] = None,
     translations: Optional[Translations] = None,
     on_change: Optional[Callable] = None,
-    # Deprecated. Just for backward compatibility
-    video_transformer_factory: None = None,
-    async_transform: Optional[bool] = None,
 ) -> WebRtcStreamerContext:
     # XXX: We wanted something like `WebRtcStreamerContext[None, None]`
     # as the return value, but could not find a good solution
@@ -315,9 +310,6 @@ def webrtc_streamer(
     audio_html_attrs: Optional[Union[AudioHTMLAttributes, Dict]] = None,
     translations: Optional[Translations] = None,
     on_change: Optional[Callable] = None,
-    # Deprecated. Just for backward compatibility
-    video_transformer_factory: None = None,
-    async_transform: Optional[bool] = None,
 ) -> WebRtcStreamerContext[VideoProcessorT, Any]:
     pass
 
@@ -355,9 +347,6 @@ def webrtc_streamer(
     audio_html_attrs: Optional[Union[AudioHTMLAttributes, Dict]] = None,
     translations: Optional[Translations] = None,
     on_change: Optional[Callable] = None,
-    # Deprecated. Just for backward compatibility
-    video_transformer_factory: None = None,
-    async_transform: Optional[bool] = None,
 ) -> WebRtcStreamerContext[Any, AudioProcessorT]:
     pass
 
@@ -395,9 +384,6 @@ def webrtc_streamer(
     audio_html_attrs: Optional[Union[AudioHTMLAttributes, Dict]] = None,
     translations: Optional[Translations] = None,
     on_change: Optional[Callable] = None,
-    # Deprecated. Just for backward compatibility
-    video_transformer_factory: None = None,
-    async_transform: Optional[bool] = None,
 ) -> WebRtcStreamerContext[VideoProcessorT, AudioProcessorT]:
     pass
 
@@ -434,30 +420,7 @@ def webrtc_streamer(
     audio_html_attrs: Optional[Union[AudioHTMLAttributes, Dict]] = None,
     translations: Optional[Translations] = None,
     on_change: Optional[Callable] = None,
-    # Deprecated. Just for backward compatibility
-    video_transformer_factory=None,
-    async_transform: Optional[bool] = None,
 ) -> WebRtcStreamerContext[VideoProcessorT, AudioProcessorT]:
-    # Backward compatibility
-    if video_transformer_factory is not None:
-        warnings.warn(
-            "The argument video_transformer_factory is deprecated. "
-            "Use video_processor_factory instead.\n"
-            "See https://github.com/whitphx/streamlit-webrtc#for-users-since-versions-020",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        video_processor_factory = video_transformer_factory
-    if async_transform is not None:
-        warnings.warn(
-            "The argument async_transform is deprecated. "
-            "Use async_processing instead.\n"
-            "See https://github.com/whitphx/streamlit-webrtc#for-users-since-versions-020",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        async_processing = async_transform
-
     # `rtc_configuration` is a shorthand to configure both frontend and server.
     # `frontend_rtc_configuration` or `server_rtc_configuration` are prioritized.
     if frontend_rtc_configuration is None:


### PR DESCRIPTION
## Summary

Both arguments of `webrtc_streamer()` have been raising `DeprecationWarning` since v0.20 (2021), forwarding to the modern `video_processor_factory` / `async_processing` names. Per `refactoring/02-delete-dead-code.md` §2.2, drop them.

- Remove the kwargs from all four `@overload` signatures and from the main definition.
- Remove the `if video_transformer_factory is not None: ... warnings.warn(...)` forwarding block (and its sibling for `async_transform`).
- Drop the now-unused `import warnings`.
- Update the `video_transformer` property's docstring (it referenced the removed kwarg by name).
- Update the `README.md` line under "For users since versions `<0.20`" to say "have been removed" instead of "are deprecated."

## Breaking change

Users still passing `video_transformer_factory=...` or `async_transform=...` will now hit `TypeError`. Documented in the `Removed` changelog fragment.

## Test plan

- [x] `uv run pytest` green
- [x] `uv run mypy streamlit_webrtc` green
- [x] `uv run pre-commit run --all-files` green (ruff / ruff-format / mypy)
- [ ] CI green

## Refs

`refactoring/02-delete-dead-code.md` §2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Breaking Changes
* Removed deprecated parameters `video_transformer_factory` and `async_transform`. Migrate to `video_processor_factory` and `async_processing` respectively.

## Documentation
* Updated API documentation reflecting removal of previously deprecated parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->