### PR TITLE
refactor: decouple WebRtcWorker from the Streamlit runtime

### DIFF
--- a/changelog.d/20260516_163535_t.yic.yt_decouple_worker_from_runtime.md
+++ b/changelog.d/20260516_163535_t.yic.yt_decouple_worker_from_runtime.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Decouple `WebRtcWorker` from the Streamlit `Runtime` singleton at runtime. The worker now resolves its event loop and `MediaRelay` once at construction (still defaulting to the Streamlit-bound globals), and accepts `loop=` / `relay=` keyword-only kwargs so callers — e.g. tests — can inject their own. `get_this_session_info()` also returns `None` instead of raising when no Streamlit `Runtime` is present, making `SessionShutdownObserver` a no-op outside a live session. No behavior change for the Streamlit-driven code path.

--- a/streamlit_webrtc/session_info.py
+++ b/streamlit_webrtc/session_info.py
@@ -18,8 +18,14 @@ def get_session_id() -> str:
 
 
 def get_this_session_info() -> Optional[SessionInfo]:
-    session_id = get_session_id()
-    return Runtime.instance()._session_mgr.get_session_info(session_id)  # type: ignore
+    # Both lookups can fail when called outside a live Streamlit run
+    # (e.g. unit tests, or worker threads spawned before a Runtime exists).
+    # Return None so callers can no-op rather than crash.
+    try:
+        session_id = get_session_id()
+        return Runtime.instance()._session_mgr.get_session_info(session_id)  # type: ignore
+    except (NoSessionError, RuntimeError):
+        return None
 
 
 def get_script_run_count(session_info: SessionInfo) -> int:

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -380,12 +380,22 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
         audio_receiver_size: int,
         sendback_video: bool,
         sendback_audio: bool,
+        *,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        relay: Optional[MediaRelay] = None,
     ) -> None:
+        # Resolve runtime-bound dependencies once at construction so subsequent
+        # methods can run without touching Streamlit's Runtime singleton.
+        # Callers that own their own loop/relay (e.g. tests) can inject them;
+        # if they do, they must have constructed the relay on the same loop.
+        self._loop = loop if loop is not None else get_global_event_loop()
+        self._relay = relay if relay is not None else get_global_relay()
+
         self._process_offer_thread: Union[threading.Thread, None] = None
         self.pc = RTCPeerConnection(rtc_configuration)
         self._answer_queue: queue.Queue = queue.Queue()
 
-        with loop_context(get_global_event_loop()):
+        with loop_context(self._loop):
             self._remote_description_set = asyncio.Event()
 
         self.mode = mode
@@ -453,7 +463,7 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
             "_process_offer_thread_impl starts",
         )
 
-        loop = get_global_event_loop()
+        loop = self._loop
         asyncio.set_event_loop(loop)
 
         offer = RTCSessionDescription(sdp, type_)
@@ -519,7 +529,7 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
         self._video_receiver = video_receiver
         self._audio_receiver = audio_receiver
 
-        relay = get_global_relay()
+        relay = self._relay
 
         source_audio_track = None
         source_video_track = None
@@ -650,8 +660,9 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
 
     def add_ice_candidate(self, candidate: RTCIceCandidate):
         logger.info("Adding ICE candidate: %s", candidate)
-        loop = get_global_event_loop()
-        asyncio.run_coroutine_threadsafe(self._add_ice_candidate(candidate), loop=loop)
+        asyncio.run_coroutine_threadsafe(
+            self._add_ice_candidate(candidate), loop=self._loop
+        )
 
     async def _add_ice_candidate(self, candidate: RTCIceCandidate):
         # Wait until `setRemoteDescription` is called which sets up the transceiver
@@ -761,7 +772,7 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
             self._process_offer_thread = None
 
         if self.pc and self.pc.connectionState != "closed":
-            loop = get_global_event_loop()
+            loop = self._loop
             if loop.is_running():
                 asyncio.run_coroutine_threadsafe(self.pc.close(), loop=loop)
             else:


### PR DESCRIPTION
## Summary

`WebRtcWorker` now resolves its event loop and `MediaRelay` once at construction instead of reaching into Streamlit's `Runtime.instance()` from inside `_process_offer_thread_impl`, `add_ice_candidate`, and `stop`. Tests (and other non-Streamlit callers) can now construct a worker without a live `Runtime`.

Implements `refactoring/04-decouple-worker-from-streamlit-runtime.md`.

## Changes

- **`WebRtcWorker.__init__`** accepts two new keyword-only kwargs: `loop=Optional[asyncio.AbstractEventLoop]` and `relay=Optional[MediaRelay]`. When omitted, the worker still calls `get_global_event_loop()` / `get_global_relay()` — so the Streamlit-driven code path is byte-for-byte the same.
- The five internal call sites (`webrtc.py:388, 456, 522, 653, 764`) now read from `self._loop` / `self._relay`. The `Runtime`-hop happens once.
- **`get_this_session_info()`** now catches `NoSessionError` and `RuntimeError` and returns `None`, matching its already-declared `Optional[SessionInfo]` return type. This makes `SessionShutdownObserver` a graceful no-op when no Streamlit session exists (it already had an `if session_info:` guard). Both call sites (`shutdown.py:23`, `component.py:540`) already handled the `None` case.

## Why the alternative path (path B from the plan)

The plan offered two options: (A) add a `session_shutdown_observer_factory=` injection point, or (B) make `SessionShutdownObserver` no-op gracefully when no session can be resolved. (B) was already 90% there — `SessionShutdownObserver.__init__` had `if session_info:` — the only remaining gap was `get_this_session_info()` raising before returning. Fixing that there is cleaner than threading a third constructor parameter through the worker.

## Test plan

- [x] `uv run pytest` green
- [x] `uv run mypy streamlit_webrtc` green
- [x] `uv run pre-commit run --all-files` green (ruff / ruff-format / mypy)
- [ ] CI green

## Refs

`refactoring/04-decouple-worker-from-streamlit-runtime.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when components operate outside active Streamlit runtime, preventing unexpected errors in edge cases.

* **Chores**
  * Enhanced internal architecture to improve testability and support for worker thread scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->