### PR TITLE
refactor: collapse WebRtcStreamerContext passthrough properties into a descriptor

### DIFF
--- a/changelog.d/20260516_170124_t.yic.yt_streamer_context_descriptor.md
+++ b/changelog.d/20260516_170124_t.yic.yt_streamer_context_descriptor.md
@@ -1,0 +1,7 @@
+### Removed
+
+- Drop the long-deprecated `WebRtcStreamerContext.video_transformer` property (deprecated since v0.20, 2021). Use `video_processor` instead.
+
+### Chore
+
+- Collapse the eight repeated worker-passthrough properties on `WebRtcStreamerContext` (`video_receiver`, `audio_receiver`, `source_video_track`, `source_audio_track`, `input_video_track`, `input_audio_track`, `output_video_track`, `output_audio_track`) into a typed descriptor. Behavior is unchanged for users; the attributes still return `None` when no worker is attached.

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -12,6 +12,7 @@ from typing import (
     Generic,
     NamedTuple,
     Optional,
+    TypeVar,
     Union,
     cast,
     overload,
@@ -87,6 +88,34 @@ class ComponentValueSnapshot(NamedTuple):
     run_count: int
 
 
+_T = TypeVar("_T")
+
+
+class _WorkerForwarded(Generic[_T]):
+    """Read-only descriptor that forwards attribute access to the live worker.
+
+    Returns ``None`` when no worker is attached, matching what every previous
+    hand-rolled passthrough property used to return. The descriptor's typed
+    ``__get__`` overload is what gives users back the original
+    ``Optional[T]`` shape on attribute access.
+    """
+
+    def __init__(self, attr_name: str) -> None:
+        self._attr_name = attr_name
+
+    @overload
+    def __get__(
+        self, instance: None, owner: Optional[type] = None
+    ) -> "_WorkerForwarded[_T]": ...
+    @overload
+    def __get__(self, instance: Any, owner: Optional[type] = None) -> Optional[_T]: ...
+    def __get__(self, instance: Any, owner: Optional[type] = None) -> Any:
+        if instance is None:
+            return self
+        worker = instance._get_worker()
+        return getattr(worker, self._attr_name) if worker else None
+
+
 class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
     _state: WebRtcStreamerState
     _worker_ref: "Optional[weakref.ReferenceType[WebRtcWorker[VideoProcessorT, AudioProcessorT]]]"  # noqa
@@ -95,6 +124,17 @@ class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
     _worker_creation_lock: threading.Lock
     _sdp_answer_json: Optional[str]
     _is_sdp_answer_sent: bool
+
+    # Passthrough attributes forwarded to the worker. Each returns the
+    # worker's attribute when a worker is attached, otherwise None.
+    video_receiver = _WorkerForwarded[VideoReceiver]("video_receiver")
+    audio_receiver = _WorkerForwarded[AudioReceiver]("audio_receiver")
+    source_video_track = _WorkerForwarded[MediaStreamTrack]("source_video_track")
+    source_audio_track = _WorkerForwarded[MediaStreamTrack]("source_audio_track")
+    input_video_track = _WorkerForwarded[MediaStreamTrack]("input_video_track")
+    input_audio_track = _WorkerForwarded[MediaStreamTrack]("input_audio_track")
+    output_video_track = _WorkerForwarded[MediaStreamTrack]("output_video_track")
+    output_audio_track = _WorkerForwarded[MediaStreamTrack]("output_audio_track")
 
     def __init__(
         self,
@@ -153,64 +193,13 @@ class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
         # so we can ignore that type here by casting the type into AudioProcessorT only.
         return cast(AudioProcessorT, worker.audio_processor) if worker else None
 
-    @property
-    def video_transformer(self) -> Optional[VideoProcessorT]:
-        """
-        A video transformer instance which has been created through
-        the callable provided as `video_transformer_factory` argument
-        to `webrtc_streamer()`.
-
-        .. deprecated:: 0.20.0
-        """
-        worker = self._get_worker()
-        return cast(VideoProcessorT, worker.video_processor) if worker else None
-
-    @property
-    def video_receiver(self) -> Optional[VideoReceiver]:
-        worker = self._get_worker()
-        return worker.video_receiver if worker else None
-
-    @property
-    def audio_receiver(self) -> Optional[AudioReceiver]:
-        worker = self._get_worker()
-        return worker.audio_receiver if worker else None
-
-    @property
-    def source_video_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.source_video_track if worker else None
-
-    @property
-    def source_audio_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.source_audio_track if worker else None
-
-    @property
-    def input_video_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.input_video_track if worker else None
-
-    @property
-    def input_audio_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.input_audio_track if worker else None
-
-    @property
-    def output_video_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.output_video_track if worker else None
-
-    @property
-    def output_audio_track(self) -> Optional[MediaStreamTrack]:
-        worker = self._get_worker()
-        return worker.output_audio_track if worker else None
-
 
 def generate_frontend_component_key(original_key: str) -> str:
-    return (
-        original_key + r':frontend 6)r])0Gea7e#2E#{y^i*_UzwU"@RJP<z'
-    )  # Random string to avoid conflicts.
-    # XXX: Any other cleaner way to ensure the key does not conflict?
+    # The frontend component is registered in `st.session_state` under a key
+    # that must not collide with the user's own `key=` (which we also store
+    # the `WebRtcStreamerContext` under). Appending a long, unlikely-to-be-typed
+    # suffix is the simplest collision avoidance — it's our salt, not a secret.
+    return original_key + r':frontend 6)r])0Gea7e#2E#{y^i*_UzwU"@RJP<z'
 
 
 def compile_state(component_value) -> WebRtcStreamerState:

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -94,10 +94,10 @@ _T = TypeVar("_T")
 class _WorkerForwarded(Generic[_T]):
     """Read-only descriptor that forwards attribute access to the live worker.
 
-    Returns ``None`` when no worker is attached, matching what every previous
-    hand-rolled passthrough property used to return. The descriptor's typed
-    ``__get__`` overload is what gives users back the original
-    ``Optional[T]`` shape on attribute access.
+    Returns ``None`` when no worker is attached — the worker is held via a
+    weakref on the enclosing context, so it can also disappear under us
+    between accesses. The overloaded ``__get__`` lets type checkers see the
+    attribute as ``Optional[_T]`` on instance access.
     """
 
     def __init__(self, attr_name: str) -> None:

--- a/tests/streamer_context_test.py
+++ b/tests/streamer_context_test.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock
+
+from streamlit_webrtc.component import WebRtcStreamerContext, WebRtcStreamerState
+
+
+def _make_context(worker):
+    return WebRtcStreamerContext(
+        worker=worker, state=WebRtcStreamerState(playing=False, signalling=False)
+    )
+
+
+def test_worker_forwarded_returns_none_when_no_worker():
+    ctx = _make_context(worker=None)
+    assert ctx.video_receiver is None
+    assert ctx.audio_receiver is None
+    assert ctx.source_video_track is None
+    assert ctx.source_audio_track is None
+    assert ctx.input_video_track is None
+    assert ctx.input_audio_track is None
+    assert ctx.output_video_track is None
+    assert ctx.output_audio_track is None
+
+
+def test_worker_forwarded_reads_from_attached_worker():
+    worker = Mock()
+    worker.video_receiver = "vr"
+    worker.audio_receiver = "ar"
+    worker.source_video_track = "svt"
+    worker.source_audio_track = "sat"
+    worker.input_video_track = "ivt"
+    worker.input_audio_track = "iat"
+    worker.output_video_track = "ovt"
+    worker.output_audio_track = "oat"
+
+    ctx = _make_context(worker=worker)
+
+    assert ctx.video_receiver == "vr"
+    assert ctx.audio_receiver == "ar"
+    assert ctx.source_video_track == "svt"
+    assert ctx.source_audio_track == "sat"
+    assert ctx.input_video_track == "ivt"
+    assert ctx.input_audio_track == "iat"
+    assert ctx.output_video_track == "ovt"
+    assert ctx.output_audio_track == "oat"
+
+
+def test_worker_forwarded_returns_none_after_worker_garbage_collected():
+    # WebRtcStreamerContext holds the worker via a weakref, so once the
+    # original reference goes away, the descriptor should fall back to None
+    # just as if no worker had been attached.
+    worker = Mock()
+    worker.video_receiver = "vr"
+    ctx = _make_context(worker=worker)
+    assert ctx.video_receiver == "vr"
+
+    del worker
+    assert ctx.video_receiver is None


### PR DESCRIPTION
## Summary

Implements `refactoring/08-cleanup-webrtc-streamer-context.md` — **Part A1** (descriptor refactor), **Part C** salt comment, and the `video_transformer` removal from Part C.

The eight identical worker-passthrough properties on `WebRtcStreamerContext` (`video_receiver`, `audio_receiver`, `source_video_track`, `source_audio_track`, `input_video_track`, `input_audio_track`, `output_video_track`, `output_audio_track`) all had the same shape:

```python
@property
def output_audio_track(self) -> Optional[MediaStreamTrack]:
    worker = self._get_worker()
    return worker.output_audio_track if worker else None
```

Replaced with one typed descriptor:

```python
class _WorkerForwarded(Generic[_T]):
    def __init__(self, attr_name: str) -> None: ...
    @overload
    def __get__(self, instance: None, owner=None) -> "_WorkerForwarded[_T]": ...
    @overload
    def __get__(self, instance: Any, owner=None) -> Optional[_T]: ...

class WebRtcStreamerContext(...):
    video_receiver = _WorkerForwarded[VideoReceiver]("video_receiver")
    audio_receiver = _WorkerForwarded[AudioReceiver]("audio_receiver")
    source_video_track = _WorkerForwarded[MediaStreamTrack]("source_video_track")
    # ... 5 more
```

User-facing behavior is unchanged; the `Optional[T]` return type is preserved via the descriptor's typed `__get__` overloads. The new `tests/streamer_context_test.py` covers no-worker, attached-worker, and weakref-collected cases.

## What's still hand-rolled and why

- **`video_processor`, `audio_processor`** kept as `@property`. They carry meaningful comments explaining why the static type narrows `Union[T, CallbackAttachableProcessor]` → `T`. Dropping those comments would lose context for future readers.
- **`video_transformer`** removed (Part C bullet). Deprecated since v0.20 (2021). The matching `video_transformer_factory` kwarg removal is in PR #2446 — same flavor, same release cycle.

## Drive-by: salt comment

`generate_frontend_component_key` had `# Random string to avoid conflicts.` next to the salt + `# XXX: Any other cleaner way to ensure the key does not conflict?`. Replaced with a calmer one-paragraph explanation of *why* the salt exists (frontend-key collision with the user-supplied `key=`). The salt value is unchanged — flipping it to a calmer sentinel was the other Part-C option, but carries a non-zero risk of session-state weirdness across rolling deploys, and the existing string works fine.

## Decisions deferred

- **Part A3** (drop properties, expose `.worker` directly) — public-API change; needs a deprecation cycle.
- **Part B1/B2** (overload consolidation) — B1 needs the Python floor at ≥3.11 (currently 3.10 until Oct 2026); B2 (drop overloads entirely) is a public-API call about whether users rely on the typed narrowing.

Both are worth coming back to but shouldn't be folded into this PR.

## Test plan

- [x] `uv run pytest` green — including the new `tests/streamer_context_test.py`
- [x] `uv run mypy streamlit_webrtc` green
- [x] `uv run pre-commit run --all-files` green
- [ ] CI green

## Refs

`refactoring/08-cleanup-webrtc-streamer-context.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecated**
  * Removed long-deprecated video_transformer property; use video_processor instead.

* **Refactor**
  * Consolidated multiple worker-backed passthrough properties into a single typed descriptor; user-visible behavior unchanged (properties still return None when no worker is attached).

* **Tests**
  * Added tests covering worker-backed property forwarding and garbage-collection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->