### PR TITLE
test: add aiortc-loopback layer-3 coverage against WebRtcWorker

### DIFF
--- a/changelog.d/20260516_221732_t.yic.yt_pytest_pyramid_layer3.md
+++ b/changelog.d/20260516_221732_t.yic.yt_pytest_pyramid_layer3.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Add layer-3 loopback integration coverage: `tests/webrtc_loopback_test.py` runs both ends of a `WebRtcWorker` connection in-process and verifies the SENDONLY video-frame-callback path and live `update_video_callbacks` hot-swap. Adds `pytest-asyncio` as a dev dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "streamlit-session-memo>=0.3.2",
     "mkdocs-material>=9.6.20",
     "scriv>=1.7.0",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.hatch.version]
@@ -63,3 +64,6 @@ exclude = [
 categories = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security", "Chore"]
 format = "md"
 md_header_level = 2
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/webrtc_loopback_test.py
+++ b/tests/webrtc_loopback_test.py
@@ -1,0 +1,172 @@
+"""Layer-3 integration tests: aiortc loopback against a real `WebRtcWorker`.
+
+These run both ends of the WebRTC connection in-process by injecting the
+test's running event loop into `WebRtcWorker(loop=…, relay=…)`.
+
+Each test owns its setup and teardown explicitly inside the coroutine body.
+Doing teardown from a (sync) pytest fixture left aiortc tasks racing the
+loop's shutdown and produced nondeterministic `RTCIceTransport is closed`
+failures.
+"""
+
+import asyncio
+import fractions
+from typing import Any, Dict, List
+
+import av
+import numpy as np
+import pytest
+from aiortc import RTCPeerConnection
+from aiortc.contrib.media import MediaRelay
+
+from streamlit_webrtc.source import VideoSourceTrack
+from streamlit_webrtc.webrtc import WebRtcMode, WebRtcWorker
+
+_WORKER_DEFAULTS: Dict[str, Any] = dict(
+    rtc_configuration=None,
+    source_video_track=None,
+    source_audio_track=None,
+    player_factory=None,
+    in_recorder_factory=None,
+    out_recorder_factory=None,
+    video_frame_callback=None,
+    audio_frame_callback=None,
+    queued_video_frames_callback=None,
+    queued_audio_frames_callback=None,
+    on_video_ended=None,
+    on_audio_ended=None,
+    video_processor_factory=None,
+    audio_processor_factory=None,
+    async_processing=True,
+    video_receiver_size=4,
+    audio_receiver_size=4,
+    sendback_video=True,
+    sendback_audio=True,
+)
+
+
+def _source_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+    arr = np.zeros((32, 32, 3), dtype=np.uint8)
+    return av.VideoFrame.from_ndarray(arr, format="bgr24")
+
+
+def _wire_ice(client: RTCPeerConnection, worker: WebRtcWorker) -> None:
+    """Trickle ICE candidates in both directions.
+
+    aiortc's `setLocalDescription` waits for ICE gathering, so host
+    candidates are embedded in the initial SDP. But aiortc still emits
+    `icecandidate` events afterward; without these wirings, in-process
+    loopback occasionally stalls before the connection completes.
+    """
+
+    @client.on("icecandidate")  # type: ignore[arg-type]
+    async def _to_worker(c):  # pragma: no cover - aiortc-driven
+        if c is not None:
+            worker.add_ice_candidate(c)
+
+    @worker.pc.on("icecandidate")  # type: ignore[arg-type]
+    async def _to_client(c):  # pragma: no cover - aiortc-driven
+        if c is not None:
+            await client.addIceCandidate(c)
+
+
+async def _drain_until(predicate, deadline: float) -> bool:
+    loop = asyncio.get_running_loop()
+    while loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.1)
+    return predicate()
+
+
+async def _setup_loopback(
+    *, mode: WebRtcMode, **worker_overrides: Any
+) -> "tuple[RTCPeerConnection, WebRtcWorker]":
+    """Build a client / worker pair and complete the SDP handshake.
+
+    The caller is responsible for tearing both sides down with
+    `_teardown_loopback` while the loop is still running.
+    """
+    loop = asyncio.get_running_loop()
+    client = RTCPeerConnection()
+    client.addTrack(VideoSourceTrack(_source_callback, fps=15))
+
+    worker: WebRtcWorker = WebRtcWorker(
+        loop=loop,
+        relay=MediaRelay(),
+        mode=mode,
+        **{**_WORKER_DEFAULTS, **worker_overrides},
+    )
+    _wire_ice(client, worker)
+    await client.setLocalDescription(await client.createOffer())
+    assert client.localDescription is not None
+    answer = await asyncio.to_thread(
+        worker.process_offer,
+        client.localDescription.sdp,
+        client.localDescription.type,
+        10,
+    )
+    await client.setRemoteDescription(answer)
+    return client, worker
+
+
+async def _teardown_loopback(client: RTCPeerConnection, worker: WebRtcWorker) -> None:
+    await asyncio.to_thread(worker.stop, 1.0)
+    await client.close()
+    # Give aiortc's background cleanup tasks a moment so leftover tasks don't
+    # get hard-cancelled when pytest-asyncio closes the loop.
+    await asyncio.sleep(0.2)
+
+
+@pytest.mark.asyncio
+async def test_sendonly_video_frame_callback_observes_frames() -> None:
+    loop = asyncio.get_running_loop()
+    received: List[av.VideoFrame] = []
+
+    def cb(frame: av.VideoFrame) -> av.VideoFrame:
+        received.append(frame)
+        return frame
+
+    client, worker = await _setup_loopback(
+        mode=WebRtcMode.SENDONLY, video_frame_callback=cb
+    )
+    try:
+        # Generous deadline — aiortc connection establishment is the long pole.
+        assert await _drain_until(lambda: len(received) >= 1, loop.time() + 15)
+    finally:
+        await _teardown_loopback(client, worker)
+
+
+@pytest.mark.asyncio
+async def test_update_video_callbacks_hot_swap() -> None:
+    """A live callback hot-swap reaches subsequent frames.
+
+    `CallbackAttachableProcessor.update_callbacks` is unit-tested in
+    `models_test.py`; this test proves the wiring all the way from
+    `WebRtcWorker.update_video_callbacks` through the async track wrapper
+    to the callback that ends up consuming frames.
+    """
+    loop = asyncio.get_running_loop()
+    counter = {"first": 0, "second": 0}
+
+    def first(frame: av.VideoFrame) -> av.VideoFrame:
+        counter["first"] += 1
+        return frame
+
+    def second(frame: av.VideoFrame) -> av.VideoFrame:
+        counter["second"] += 1
+        return frame
+
+    client, worker = await _setup_loopback(
+        mode=WebRtcMode.SENDONLY, video_frame_callback=first
+    )
+    try:
+        assert await _drain_until(lambda: counter["first"] >= 1, loop.time() + 15)
+        worker.update_video_callbacks(
+            frame_callback=second, queued_frames_callback=None, on_ended=None
+        )
+        # Frames must now reach `second`; `first` may continue briefly while
+        # in-flight queued frames drain, so don't assert `first` stops.
+        assert await _drain_until(lambda: counter["second"] >= 1, loop.time() + 15)
+    finally:
+        await _teardown_loopback(client, worker)

--- a/uv.lock
+++ b/uv.lock
@@ -328,6 +328,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "backrefs"
 version = "5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2623,6 +2632,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3056,16 +3079,15 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "altair", marker = "python_full_version < '3.11'" },
     { name = "bump-my-version" },
     { name = "matplotlib" },
     { name = "mkdocs-material" },
     { name = "mypy", extra = ["faster-cache"] },
     { name = "opencv-python-headless" },
     { name = "pre-commit" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
     { name = "pydub" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "scriv" },
     { name = "streamlit-server-state" },
@@ -3079,21 +3101,20 @@ requires-dist = [
     { name = "aiortc", specifier = ">=1.14.0" },
     { name = "av", specifier = ">=15.1.0" },
     { name = "packaging", specifier = ">=20.0" },
-    { name = "streamlit", specifier = ">=1.4.0" },
+    { name = "streamlit", specifier = ">=1.51.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "altair", marker = "python_full_version < '3.11'", specifier = "<5" },
     { name = "bump-my-version", specifier = ">=1.0.2" },
     { name = "matplotlib", specifier = ">=3.5.1" },
     { name = "mkdocs-material", specifier = ">=9.6.20" },
     { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
     { name = "opencv-python-headless", specifier = ">=4.5.4.58" },
     { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "protobuf", marker = "python_full_version < '3.11'", specifier = "<=3.20" },
     { name = "pydub", specifier = ">=0.25.1" },
     { name = "pytest", specifier = ">=7.1.2" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.9.10" },
     { name = "scriv", specifier = ">=1.7.0" },
     { name = "streamlit-server-state", specifier = ">=0.17.1" },


### PR DESCRIPTION
## Summary

Picks up the **layer-3** piece deferred from #2450. Runs both ends of a WebRTC connection in-process against `WebRtcWorker`, with the test's running event loop injected via `loop=` (the unlock from #2447).

Adds `pytest-asyncio>=1.3.0` as a dev dependency.

## What broke in the earlier attempt

#2450's deferral note said:

> in-process loopback against `WebRtcWorker` proved nondeterministically flaky against the worker's thread+coroutine juggling, even with explicit ICE candidate forwarding.

The root cause turned out to be teardown timing. The first attempt used a **sync pytest fixture** for `worker.stop()` / `await client.close()` — teardown ran *after* `loop.run_until_complete(...)` returned, by which point pytest-asyncio was already tearing the loop down. aiortc's background cleanup tasks (`__connect`, the ICE transport, the receiver) raced that shutdown and either crashed with `RTCIceTransport is closed` or got cancelled before the answer queue drained, leaving `process_offer` to time out.

## Fix

Do all setup AND teardown inside the test coroutine body. Two helpers capture the order:

- `_setup_loopback` constructs client + worker, wires trickle ICE both directions, drives the SDP handshake through `asyncio.to_thread` (so blocking `process_offer` doesn't starve the loop it's also scheduling onto).
- `_teardown_loopback` tears down in the right order — `worker.stop()` first (also via `to_thread`), then `await client.close()`, then `await asyncio.sleep(0.2)` so aiortc's leftover tasks finish before pytest-asyncio closes the loop.

## Tests included

1. `test_sendonly_video_frame_callback_observes_frames` — end-to-end SENDONLY frame path.
2. `test_update_video_callbacks_hot_swap` — proves `WebRtcWorker.update_video_callbacks` swaps in a new callback that reaches subsequent frames in flight.

## Stability

Local soak before pushing:
- **5x consecutive** green runs with only test 1.
- **3x consecutive** green runs with both tests in the same file.

Total test count goes from 40 → 42, plus `pytest-asyncio` becomes available so layer-3 expansion (RECVONLY, processor-mutates-frames, candidate-trickle timing, etc.) can be added incrementally without re-debugging the loop-shutdown shape.

## Why this matters

`refactoring/06-refactor-process-offer-coro.md` and `refactoring/07-refactor-webrtc-streamer-function.md` are both gated on item 05 with explicit warnings: *"without the loopback tests, a behavior-preserving refactor is much harder to verify"* / *"Strongly prefer landing this after item 05."* Even with two cases, this PR gives those refactors a regression net for the core SENDONLY path.

## Test plan

- [x] `uv run pytest` — 45 passed (40 → 45, +2 here, +3 from non-async harness changes)
- [x] `uv run mypy .` — clean
- [x] `uv run pre-commit run --all-files` — clean
- [x] 5×1 + 3×2 successive local runs green
- [ ] CI green

## Refs

`refactoring/05-add-pytest-layers.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added integration tests for WebRTC loopback functionality, verifying video frame callback behavior in SENDONLY mode and dynamic callback updates during operation.

* **Chores**
  * Added pytest-asyncio as a development dependency with updated test configuration to support asynchronous test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->