### PR TITLE
refactor: decouple MediaStreamMixTrack from the Streamlit runtime + add mix tests

### DIFF
--- a/changelog.d/20260517_150252_t.yic.yt_decouple_mix_track.md
+++ b/changelog.d/20260517_150252_t.yic.yt_decouple_mix_track.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Decouple `MediaStreamMixTrack` from the Streamlit `Runtime` singleton, mirroring the `WebRtcWorker` change from #2447. The constructor now accepts optional `loop=` and `relay=` keyword-only kwargs and stores them on the instance; existing callers that omit them resolve the same Streamlit-bound globals as before. Adds three layer-2 mix tests (`tests/mix_test.py`) that exercise the single-input, multi-input, and `mixer_output_interval` paths against the test's running event loop.

--- a/streamlit_webrtc/mix.py
+++ b/streamlit_webrtc/mix.py
@@ -10,7 +10,7 @@ from typing import Callable, Generic, List, NamedTuple, Optional, Union, cast
 
 import av
 from aiortc import MediaStreamTrack
-from aiortc.contrib.media import RelayStreamTrack
+from aiortc.contrib.media import MediaRelay, RelayStreamTrack
 from aiortc.mediastreams import MediaStreamError
 from av.frame import Frame
 from av.packet import Packet
@@ -144,16 +144,27 @@ class MediaStreamMixTrack(MediaStreamTrack, Generic[FrameT]):
         kind: str,
         mixer_callback: MixerCallback[FrameT],
         mixer_output_interval: float = 1 / 30,
+        *,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+        relay: Optional[MediaRelay] = None,
     ) -> None:
+        # Resolve runtime-bound dependencies once at construction so subsequent
+        # methods can run without touching Streamlit's Runtime singleton.
+        # Callers that own their own loop/relay (e.g. tests) can inject them;
+        # if they do, they must have constructed the relay on the same loop.
+        resolved_loop = loop if loop is not None else get_global_event_loop()
+        self._relay = relay if relay is not None else get_global_relay()
+
         self.kind = kind
         self._mixer_callback: MixerCallback[FrameT] = mixer_callback
         self._mixer_callback_lock = threading.Lock()
 
         self.mixer_output_interval = mixer_output_interval
 
-        loop = get_global_event_loop()
-
-        with loop_context(loop):
+        with loop_context(resolved_loop):
+            # aiortc's `MediaStreamTrack.__init__` sets its own `self._loop`,
+            # so our assignment to `self._loop` has to land after `super()`
+            # to avoid being clobbered.
             super().__init__()
 
             self._queue = asyncio.Queue()
@@ -169,7 +180,7 @@ class MediaStreamMixTrack(MediaStreamTrack, Generic[FrameT]):
 
             self._latest_frames_updated_event = asyncio.Event()
 
-            self._loop = loop
+            self._loop = resolved_loop
 
             self._gather_frames_task = None
             self._mix_task = None
@@ -208,9 +219,8 @@ class MediaStreamMixTrack(MediaStreamTrack, Generic[FrameT]):
             if input_track in self._input_proxies:
                 return
 
-            relay = get_global_relay()
             with loop_context(self._loop):
-                input_proxy = cast(RelayStreamTrack, relay.subscribe(input_track))
+                input_proxy = cast(RelayStreamTrack, self._relay.subscribe(input_track))
 
             self._input_proxies[input_track] = input_proxy
 

--- a/tests/mix_test.py
+++ b/tests/mix_test.py
@@ -48,7 +48,7 @@ async def test_mixer_callback_receives_a_single_input() -> None:
     received: List[List[av.VideoFrame]] = []
 
     def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
-        received.append(list(frames))
+        received.append(frames)
         return _output_frame()
 
     mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
@@ -78,7 +78,7 @@ async def test_mixer_callback_receives_multiple_inputs() -> None:
     received: List[List[av.VideoFrame]] = []
 
     def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
-        received.append(list(frames))
+        received.append(frames)
         return _output_frame()
 
     mix_track: MediaStreamMixTrack = MediaStreamMixTrack(

--- a/tests/mix_test.py
+++ b/tests/mix_test.py
@@ -1,0 +1,143 @@
+"""Layer-2 tests for `mix.MediaStreamMixTrack`.
+
+Inject the test's running loop + a fresh `MediaRelay` into the mix track
+(introduced when the class was decoupled from the Streamlit runtime), so
+the input-pumping and mixer coroutines run on the same loop the test
+itself owns. No real WebRTC connection involved — input tracks are
+simple `VideoSourceTrack`s yielding constant frames.
+"""
+
+import asyncio
+import fractions
+import time
+from typing import List
+
+import av
+import numpy as np
+import pytest
+from aiortc.contrib.media import MediaRelay
+
+from streamlit_webrtc.mix import MediaStreamMixTrack
+from streamlit_webrtc.source import VideoSourceTrack
+
+
+def _video_source_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+    arr = np.zeros((16, 16, 3), dtype=np.uint8)
+    return av.VideoFrame.from_ndarray(arr, format="bgr24")
+
+
+def _output_frame() -> av.VideoFrame:
+    arr = np.full((16, 16, 3), 7, dtype=np.uint8)
+    return av.VideoFrame.from_ndarray(arr, format="bgr24")
+
+
+async def _teardown(
+    mix_track: MediaStreamMixTrack, inputs: List[VideoSourceTrack]
+) -> None:
+    mix_track.stop()
+    for t in inputs:
+        t.stop()
+    # Give the gather / mix / input-pumping tasks a chance to unwind before
+    # pytest-asyncio closes the loop.
+    await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_mixer_callback_receives_a_single_input() -> None:
+    loop = asyncio.get_running_loop()
+    received: List[List[av.VideoFrame]] = []
+
+    def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
+        received.append(list(frames))
+        return _output_frame()
+
+    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+        kind="video",
+        mixer_callback=mixer_cb,
+        mixer_output_interval=1 / 60,
+        loop=loop,
+        relay=MediaRelay(),
+    )
+    source = VideoSourceTrack(_video_source_callback, fps=30)
+    mix_track.add_input_track(source)
+
+    try:
+        outputs = [await mix_track.recv() for _ in range(3)]
+        assert len(outputs) == 3
+        # Each invocation saw exactly one input frame — there's only one
+        # input track registered.
+        assert len(received) >= 3
+        assert all(len(frames) == 1 for frames in received[:3])
+    finally:
+        await _teardown(mix_track, [source])
+
+
+@pytest.mark.asyncio
+async def test_mixer_callback_receives_multiple_inputs() -> None:
+    loop = asyncio.get_running_loop()
+    received: List[List[av.VideoFrame]] = []
+
+    def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
+        received.append(list(frames))
+        return _output_frame()
+
+    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+        kind="video",
+        mixer_callback=mixer_cb,
+        mixer_output_interval=1 / 60,
+        loop=loop,
+        relay=MediaRelay(),
+    )
+    source_a = VideoSourceTrack(_video_source_callback, fps=30)
+    source_b = VideoSourceTrack(_video_source_callback, fps=30)
+    mix_track.add_input_track(source_a)
+    mix_track.add_input_track(source_b)
+
+    try:
+        # Drain several outputs to give both inputs time to register frames.
+        for _ in range(8):
+            await mix_track.recv()
+
+        # The mix callback's input list is built from whatever sources have
+        # delivered a frame so far — early iterations may only see one of
+        # the two because the inputs warm up independently. At least one
+        # call must include both inputs.
+        assert any(len(frames) == 2 for frames in received)
+    finally:
+        await _teardown(mix_track, [source_a, source_b])
+
+
+@pytest.mark.asyncio
+async def test_mixer_output_cadence_tracks_configured_interval() -> None:
+    """Successive `recv()` calls should be roughly spaced by `mixer_output_interval`."""
+    loop = asyncio.get_running_loop()
+    interval = 0.05  # 50ms
+
+    def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
+        return _output_frame()
+
+    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+        kind="video",
+        mixer_callback=mixer_cb,
+        mixer_output_interval=interval,
+        loop=loop,
+        relay=MediaRelay(),
+    )
+    source = VideoSourceTrack(_video_source_callback, fps=60)
+    mix_track.add_input_track(source)
+
+    try:
+        # Warm up — the first frame can land essentially immediately because
+        # the mix loop doesn't wait for an interval before producing it.
+        await mix_track.recv()
+
+        start = time.monotonic()
+        for _ in range(3):
+            await mix_track.recv()
+        elapsed = time.monotonic() - start
+
+        # 3 more frames after the warm-up means ~3 intervals of work, give
+        # generous bounds for scheduler jitter.
+        assert interval * 2 < elapsed < interval * 8
+    finally:
+        await _teardown(mix_track, [source])

--- a/tests/mix_test.py
+++ b/tests/mix_test.py
@@ -51,7 +51,7 @@ async def test_mixer_callback_receives_a_single_input() -> None:
         received.append(frames)
         return _output_frame()
 
-    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+    mix_track = MediaStreamMixTrack(
         kind="video",
         mixer_callback=mixer_cb,
         mixer_output_interval=1 / 60,
@@ -81,7 +81,7 @@ async def test_mixer_callback_receives_multiple_inputs() -> None:
         received.append(frames)
         return _output_frame()
 
-    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+    mix_track = MediaStreamMixTrack(
         kind="video",
         mixer_callback=mixer_cb,
         mixer_output_interval=1 / 60,
@@ -116,7 +116,7 @@ async def test_mixer_output_cadence_tracks_configured_interval() -> None:
     def mixer_cb(frames: List[av.VideoFrame]) -> av.VideoFrame:
         return _output_frame()
 
-    mix_track: MediaStreamMixTrack = MediaStreamMixTrack(
+    mix_track = MediaStreamMixTrack(
         kind="video",
         mixer_callback=mixer_cb,
         mixer_output_interval=interval,


### PR DESCRIPTION
## Summary

Closes the last deferral from #2450: applies the **loop / relay injection** pattern from #2447 (which originally decoupled `WebRtcWorker`) to `MediaStreamMixTrack`, then adds the **layer-2 mix tests** that were deferred because the class couldn't be constructed without a Streamlit `Runtime`.

## Refactor

`MediaStreamMixTrack.__init__` gains two optional keyword-only kwargs:

```python
def __init__(
    self,
    kind: str,
    mixer_callback: MixerCallback[FrameT],
    mixer_output_interval: float = 1 / 30,
    *,
    loop: Optional[asyncio.AbstractEventLoop] = None,
    relay: Optional[MediaRelay] = None,
) -> None:
```

When omitted, the resolver falls back to `get_global_event_loop()` and `get_global_relay()` — byte-for-byte the same behavior as before. Tests (and any non-Streamlit caller) can inject their own.

**Placement subtlety:** aiortc's `MediaStreamTrack.__init__` sets its own `self._loop` from the current event loop, so this class's `self._loop` assignment has to land *after* `super().__init__()` to avoid being clobbered. The original code already worked around this; the new version preserves the order with an explanatory comment.

## Tests

`tests/mix_test.py` adds three layer-2 cases against the test's running event loop:

| Test | What it asserts |
|---|---|
| `test_mixer_callback_receives_a_single_input` | One input track → each mixer-callback invocation gets a 1-element list |
| `test_mixer_callback_receives_multiple_inputs` | Two input tracks → at least one mixer-callback invocation gets a 2-element list (inputs warm up independently, so not every call) |
| `test_mixer_output_cadence_tracks_configured_interval` | `recv()` calls are spaced by ≈ `mixer_output_interval` (generous bounds for scheduler jitter) |

Local soak: **5× consecutive green runs**.

## Test plan

- [x] `uv run pytest` — 48 passed (45 → 48)
- [x] `uv run mypy streamlit_webrtc tests` — clean
- [x] `uv run pre-commit run --all-files` — clean
- [x] 5×5 = 25 stable mix-test runs locally
- [ ] CI green

## Refs

`refactoring/05-add-pytest-layers.md` (the deferred mix-test rows), and the precedent from `refactoring/04-decouple-worker-from-streamlit-runtime.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved media-mixing initialization to allow configuring the async runtime and media-relay used by mixers while remaining fully backward-compatible.

* **Tests**
  * Added async tests validating single- and multi-input mixing behavior, mixer correctness, and output timing/cadence against the configured interval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->