### PR TITLE
fix: support one-sided SENDRECV with source_video_track / source_audio_track

### DIFF
--- a/changelog.d/20260518_160122_t.yic.yt_sendrecv_one_sided.md
+++ b/changelog.d/20260518_160122_t.yic.yt_sendrecv_one_sided.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix SENDRECV mode silently dropping `source_video_track` / `source_audio_track` when the browser-side capture is one-sided (e.g. `media_stream_constraints={"audio": True, "video": False}` paired with a server-generated video source). The frontend now negotiates a recvonly transceiver for any kind it isn't sending (gated on `sendback_video` / `sendback_audio`), and the worker attaches the configured source to that transceiver after the offer is set.

--- a/pages/16_audio_in_video_out.py
+++ b/pages/16_audio_in_video_out.py
@@ -1,0 +1,104 @@
+"""Audio-in / video-out SENDRECV demo.
+
+The browser captures audio only, the server consumes those audio frames
+through an `audio_frame_callback`, and a server-generated video track is
+streamed back. Demonstrates that one-sided SENDRECV (peer sends one kind,
+server emits the other via `source_*_track`) is supported.
+"""
+
+import fractions
+import threading
+import time
+
+import av
+import cv2
+import numpy as np
+import streamlit as st
+from streamlit_webrtc import (
+    WebRtcMode,
+    create_video_source_track,
+    webrtc_streamer,
+)
+
+st.title("Audio In / Video Out")
+st.write(
+    "The browser sends microphone audio; the server measures its loudness "
+    "and streams back a video that visualizes the level. No video is "
+    "captured from the browser."
+)
+
+# Shared state between the audio callback (driven by the receiving track)
+# and the video source callback (driven by the outgoing track). The two
+# callbacks run on different threads, so the lock is load-bearing.
+_state = {"level": 0.0, "updated_at": 0.0}
+_state_lock = threading.Lock()
+
+
+def audio_frame_callback(frame: av.AudioFrame) -> av.AudioFrame:
+    samples = frame.to_ndarray()
+    if samples.size:
+        rms = float(np.sqrt(np.mean(np.square(samples.astype(np.float32)))))
+        # Roughly normalize int16 RMS to 0..1.
+        normalized = min(rms / 32768.0, 1.0)
+        with _state_lock:
+            _state["level"] = normalized
+            _state["updated_at"] = time.monotonic()
+    return frame
+
+
+def video_source_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+    with _state_lock:
+        level = _state["level"]
+        updated_at = _state["updated_at"]
+
+    height, width = 360, 640
+    buf = np.zeros((height, width, 3), dtype=np.uint8)
+
+    # Green bar that fills bottom-up proportional to the audio level.
+    bar_h = int(level * height)
+    if bar_h > 0:
+        buf[height - bar_h :, :, 1] = 220
+
+    cv2.putText(
+        buf,
+        f"audio level: {level:.3f}",
+        (16, 40),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.9,
+        (255, 255, 255),
+        2,
+    )
+    age = time.monotonic() - updated_at if updated_at else float("inf")
+    status = "live" if age < 1.0 else "waiting for audio..."
+    cv2.putText(
+        buf,
+        status,
+        (16, 76),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.7,
+        (200, 200, 200),
+        2,
+    )
+    return av.VideoFrame.from_ndarray(buf, format="bgr24")
+
+
+video_source_track = create_video_source_track(
+    video_source_callback, key="audio_in_video_out_source", fps=15
+)
+
+
+def on_change() -> None:
+    ctx = st.session_state["audio_in_video_out"]
+    stopped = not ctx.state.playing and not ctx.state.signalling
+    if stopped:
+        video_source_track.stop()
+
+
+webrtc_streamer(
+    key="audio_in_video_out",
+    mode=WebRtcMode.SENDRECV,
+    media_stream_constraints={"audio": True, "video": False},
+    source_video_track=video_source_track,
+    audio_frame_callback=audio_frame_callback,
+    on_change=on_change,
+)

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -669,6 +669,11 @@ def webrtc_streamer(
         audio_html_attrs=audio_html_attrs,
         translations=translations,
         desired_playing_state=desired_playing_state,
+        # `sendback_*` lets the frontend negotiate recvonly transceivers for
+        # kinds the local capture won't produce — without this, an audio-only
+        # capture cannot receive a server-generated video stream.
+        sendback_video=sendback_video,
+        sendback_audio=sendback_audio,
         on_change=_make_state_change_callback(key, frontend_key, on_change),
     )
     component_value = _restore_snapshot_if_needed(context, component_value)

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -29,6 +29,8 @@ interface WebRtcStreamerInnerProps {
   sdpAnswerJson: string | undefined;
   rtcConfiguration: RTCConfiguration | undefined;
   mediaStreamConstraints: MediaStreamConstraints | undefined;
+  sendbackVideo: boolean;
+  sendbackAudio: boolean;
   videoHtmlAttrs: Record<string, string>;
   audioHtmlAttrs: Record<string, string>;
   onComponentValueChange: (newComponentValue: ComponentValue) => void;
@@ -172,6 +174,8 @@ function WebRtcStreamer() {
   const rtcConfiguration: RTCConfiguration = renderData.args.rtc_configuration;
   const mediaStreamConstraints: MediaStreamConstraints =
     renderData.args.media_stream_constraints;
+  const sendbackVideo: boolean = renderData.args.sendback_video ?? true;
+  const sendbackAudio: boolean = renderData.args.sendback_audio ?? true;
   const videoHtmlAttrs = renderData.args.video_html_attrs;
   const audioHtmlAttrs = renderData.args.audio_html_attrs;
 
@@ -188,6 +192,8 @@ function WebRtcStreamer() {
       sdpAnswerJson={sdpAnswerJson}
       rtcConfiguration={rtcConfiguration}
       mediaStreamConstraints={mediaStreamConstraints}
+      sendbackVideo={sendbackVideo}
+      sendbackAudio={sendbackAudio}
       videoHtmlAttrs={videoHtmlAttrs}
       audioHtmlAttrs={audioHtmlAttrs}
       onComponentValueChange={setComponentValue}

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -19,6 +19,8 @@ export const useWebRtc = (
     sdpAnswerJson: string | undefined;
     rtcConfiguration: RTCConfiguration | undefined;
     mediaStreamConstraints: MediaStreamConstraints | undefined;
+    sendbackVideo: boolean;
+    sendbackAudio: boolean;
   },
   videoDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
   audioDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
@@ -166,6 +168,28 @@ export const useWebRtc = (
           for (const transceiver of pc.getTransceivers()) {
             transceiver.direction = "sendonly";
           }
+        } else if (mode === "SENDRECV") {
+          // When the local capture is one-sided (e.g. audio-only), the SDP
+          // offer ends up with only an audio m-section and the server has
+          // nowhere to attach a video sender. Add an explicit recvonly
+          // transceiver for any kind we are not sending so the server can
+          // still send back a track of that kind (driven by `source_*`).
+          // Gated on the corresponding `sendback_*` so opting out skips
+          // the extra m-section.
+          const localKinds = new Set(
+            pc
+              .getTransceivers()
+              .map((t) => t.sender.track?.kind)
+              .filter(
+                (k): k is "audio" | "video" => k === "audio" || k === "video",
+              ),
+          );
+          if (props.sendbackVideo && !localKinds.has("video")) {
+            pc.addTransceiver("video", { direction: "recvonly" });
+          }
+          if (props.sendbackAudio && !localKinds.has("audio")) {
+            pc.addTransceiver("audio", { direction: "recvonly" });
+          }
         }
       } else if (mode === "RECVONLY") {
         pc.addTransceiver("video", { direction: "recvonly" });
@@ -224,6 +248,8 @@ export const useWebRtc = (
     props.mediaStreamConstraints,
     props.mode,
     props.rtcConfiguration,
+    props.sendbackVideo,
+    props.sendbackAudio,
     state.webRtcState,
     onDevicesOpened,
     uniqueIdGenerator,

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -147,11 +147,21 @@ async def _process_offer_coro(
     def _processor_for(kind: str) -> Optional[ProcessorBase]:
         return audio_processor if kind == "audio" else video_processor
 
+    def _sendback_for(kind: str) -> bool:
+        return sendback_video if kind == "video" else sendback_audio
+
+    # Tracks which kinds the peer is actually sending. Populated by `on_track`
+    # in SENDRECV mode and consulted after `setRemoteDescription` so we can
+    # attach `source_*` for kinds the peer didn't send (e.g. audio-only input
+    # paired with a server-side video source).
+    peer_sending_kinds: Set[str] = set()
+
     if mode == WebRtcMode.SENDRECV:
 
         @pc.listens_to("track")
         def on_track(input_track: MediaStreamTrack):
             logger.info("Track %s received", input_track.kind)
+            peer_sending_kinds.add(input_track.kind)
             _notify_track_created(on_track_created, "input", input_track)
 
             # An explicitly-configured source overrides the peer track outright
@@ -169,10 +179,7 @@ async def _process_offer_coro(
                 )
             )
 
-            sendback = (
-                sendback_video if output_track.kind == "video" else sendback_audio
-            )
-            if sendback:
+            if _sendback_for(output_track.kind):
                 logger.info("Add a track %s to %s", output_track, pc)
                 pc.addTrack(relay.subscribe(output_track))
             else:
@@ -247,6 +254,32 @@ async def _process_offer_coro(
             # NOTE: Recording is not supported in this mode
             # because connecting player to recorder does not work somehow;
             # it generates unplayable movie files.
+            _notify_track_created(on_track_created, "output", output_track)
+
+    if mode == WebRtcMode.SENDRECV:
+        # `on_track` only fires for kinds the peer is sending, so when the
+        # peer offered a recvonly m-section for a kind (one-sided input,
+        # e.g. audio-only) the configured `source_*` for that kind has not
+        # been attached yet. Symmetric with the RECVONLY block above.
+        for t in pc.getTransceivers():
+            if t.kind in peer_sending_kinds:
+                continue
+            source = _source_for(t.kind)
+            if source is None:
+                continue
+            output_track = _wrap_with_processor(
+                source,
+                _processor_for(t.kind),
+                async_processing=async_processing,
+                relay=relay,
+            )
+            if _sendback_for(t.kind):
+                logger.info("Add a track %s to %s", output_track, pc)
+                pc.addTrack(relay.subscribe(output_track))
+            else:
+                logger.info("Block a track %s", output_track)
+            if out_recorder:
+                out_recorder.addTrack(relay.subscribe(output_track))
             _notify_track_created(on_track_created, "output", output_track)
 
     if video_receiver and video_receiver.hasTrack():

--- a/tests/webrtc_loopback_test.py
+++ b/tests/webrtc_loopback_test.py
@@ -11,7 +11,7 @@ failures.
 
 import asyncio
 import fractions
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import av
 import numpy as np
@@ -19,7 +19,7 @@ import pytest
 from aiortc import RTCPeerConnection
 from aiortc.contrib.media import MediaRelay
 
-from streamlit_webrtc.source import VideoSourceTrack
+from streamlit_webrtc.source import AudioSourceTrack, VideoSourceTrack
 from streamlit_webrtc.webrtc import WebRtcMode, WebRtcWorker
 
 _WORKER_DEFAULTS: Dict[str, Any] = dict(
@@ -133,6 +133,61 @@ async def test_sendonly_video_frame_callback_observes_frames() -> None:
     try:
         # Generous deadline — aiortc connection establishment is the long pole.
         assert await _drain_until(lambda: len(received) >= 1, loop.time() + 15)
+    finally:
+        await _teardown_loopback(client, worker)
+
+
+def _audio_source_callback(pts: int, time_base: fractions.Fraction) -> av.AudioFrame:
+    samples = np.zeros((1, 960), dtype=np.int16)
+    frame = av.AudioFrame.from_ndarray(samples, format="s16", layout="mono")
+    frame.sample_rate = 48000
+    return frame
+
+
+@pytest.mark.asyncio
+async def test_sendrecv_audio_only_input_with_source_video_track() -> None:
+    """SENDRECV with audio-only peer input still delivers `source_video_track`.
+
+    Regression test for the case where the developer wants to receive audio
+    from the browser AND send back a server-generated video stream. The
+    worker used to attach output tracks only inside `on_track`, which fires
+    once per incoming peer kind, so the configured `source_video_track` was
+    silently dropped when the peer didn't send video.
+    """
+    loop = asyncio.get_running_loop()
+    client = RTCPeerConnection()
+    client.addTrack(AudioSourceTrack(_audio_source_callback, sample_rate=48000))
+    # Mirror the frontend behavior: explicitly request a video stream from
+    # the server even though the client isn't sending one.
+    client.addTransceiver("video", direction="recvonly")
+
+    received_kinds: Set[str] = set()
+
+    @client.on("track")  # type: ignore[arg-type]
+    def _on_track(track):  # pragma: no cover - aiortc-driven
+        received_kinds.add(track.kind)
+
+    server_source = VideoSourceTrack(_source_callback, fps=15)
+    worker: WebRtcWorker = WebRtcWorker(
+        loop=loop,
+        relay=MediaRelay(),
+        mode=WebRtcMode.SENDRECV,
+        **{**_WORKER_DEFAULTS, "source_video_track": server_source},
+    )
+    _wire_ice(client, worker)
+    await client.setLocalDescription(await client.createOffer())
+    assert client.localDescription is not None
+    answer = await asyncio.to_thread(
+        worker.process_offer,
+        client.localDescription.sdp,
+        client.localDescription.type,
+        10,
+    )
+    await client.setRemoteDescription(answer)
+
+    try:
+        assert await _drain_until(lambda: "video" in received_kinds, loop.time() + 15)
+        assert worker.output_video_track is not None
     finally:
         await _teardown_loopback(client, worker)
 


### PR DESCRIPTION
## Summary

- Fixes SENDRECV mode silently dropping `source_video_track` / `source_audio_track` when the browser-side capture is one-sided (e.g. `media_stream_constraints={"audio": True, "video": False}` paired with a server-generated video source).
- Frontend now negotiates a `recvonly` transceiver for any kind it isn't sending in SENDRECV mode, gated on `sendback_video` / `sendback_audio` (plumbed through new component args).
- Backend now attaches the configured `source_*` for kinds the peer didn't send, after `setRemoteDescription` — symmetric with the existing RECVONLY path.

## Details

Previously, two compounding bugs broke the natural setup of "browser sends audio, server sends back video":

- **Backend** (`streamlit_webrtc/webrtc.py`): output tracks were only wired inside the `on_track` handler, which fires once per incoming peer track. With audio-only input, `on_track` fired for "audio" and never consulted `source_video_track`.
- **Frontend** (`streamlit_webrtc/frontend/src/webrtc/index.ts`): in SENDRECV, the only transceivers came from `pc.addTrack` on `getUserMedia` outputs. With audio-only constraints, the SDP offer had no video m-section for the server to attach a sender to.

The fix touches both layers so the scenario works end-to-end.

## Test plan

- [x] `uv run pytest` — 46 passed, including new `test_sendrecv_audio_only_input_with_source_video_track` regression test that loops aiortc against a real `WebRtcWorker`.
- [x] `uv run mypy .` — clean for this change (pre-existing errors in untracked `docs/examples/talk_to_openai/app.py` only).
- [x] `uv run ruff check . && uv run ruff format .` — clean.
- [x] Frontend `pnpm lint` (prettier + eslint) — clean.
- [x] Frontend `pnpm tsc -b` — clean.
- [x] Frontend `pnpm test --run` — 23 passed.
- [ ] Manual: run `streamlit run home.py`, open `pages/16_audio_in_video_out.py`, start the streamer, confirm a server-rendered audio-level visualization is received as a video stream in the browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SENDRECV mode to properly handle one-sided media capture where configured source tracks were previously silently dropped when the browser sent or received only certain media kinds.

* **New Features**
  * Added demo page showcasing one-sided SENDRECV: browser sends audio while the server generates and streams visualization video based on audio analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->