### PR TITLE
docs: document session-end callbacks; clarify class- vs function-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,39 @@ The callbacks are executed in forked threads different from the main one, so the
 * The `global` keyword does not work expectedly in the callbacks.
 * You have to care about thread-safety when accessing the same objects both from outside and inside the callbacks as stated in the section above.
 
+## Cleanup on Stop (session lifecycle)
+
+`webrtc_streamer()` accepts `on_video_ended` and `on_audio_ended` arguments — zero-argument callables that fire when the corresponding input media track ends (the user clicks "STOP", closes the page, or the connection drops). They are the recommended hook for tearing down per-session resources that the frame callbacks allocated, such as worker threads, model handles, file writers, queues, or `st.session_state` entries.
+
+```python
+import streamlit as st
+from streamlit_webrtc import webrtc_streamer
+
+
+def video_frame_callback(frame):
+    # ... process the frame, possibly initializing per-session state on first call ...
+    return frame
+
+
+def on_video_ended():
+    st.session_state.pop("my_session_resource", None)
+
+
+webrtc_streamer(
+    key="example",
+    video_frame_callback=video_frame_callback,
+    on_video_ended=on_video_ended,
+)
+```
+
+These callbacks run on `aiortc`'s asyncio loop — not Streamlit's main thread — so the same caveats as the frame callbacks apply: `st.*` calls do not work inside them, and shared state must be mutated in a thread-safe way (e.g. with a `threading.Lock`, a `queue`, or a `threading.Event`).
+
+When using the [class-based API](#class-based-callbacks), override `VideoProcessorBase.on_ended()` / `AudioProcessorBase.on_ended()` instead — they fire at the same lifecycle point.
+
 ## Class-based callbacks
-Until v0.37, the class-based callbacks were the standard.
-See the [old version of the README](https://github.com/whitphx/streamlit-webrtc/blob/v0.37.0/README.md#quick-tutorial) about it.
+The function-based callbacks (`video_frame_callback` / `audio_frame_callback`) shown above are the recommended API.
+
+Until v0.37, the class-based callbacks (`video_processor_factory` / `audio_processor_factory` taking a `VideoProcessorBase` / `AudioProcessorBase` subclass) were the standard. They are still supported for backward compatibility — see the [old version of the README](https://github.com/whitphx/streamlit-webrtc/blob/v0.37.0/README.md#quick-tutorial) for that style — but new code should prefer the function-based callbacks. The class-based API is planned to be removed in a future major release (v1.0).
 
 ## Serving from remote host
 When deploying apps to remote servers, there are some things you need to be aware of.

--- a/changelog.d/20260518_162836_t.yic.yt_triage_issues_20260518.md
+++ b/changelog.d/20260518_162836_t.yic.yt_triage_issues_20260518.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Document the `on_video_ended` / `on_audio_ended` callbacks (and the matching `VideoProcessorBase.on_ended()` / `AudioProcessorBase.on_ended()` hooks) as the recommended way to release per-session resources when a WebRTC session ends. Adds a "Cleanup on Stop" section to the README and the mkdocs tutorial, and expands the docstrings on the processor base classes to spell out when the hook fires and the threading caveat (it runs on aiortc's asyncio loop, not Streamlit's main thread). Closes #2406.
+
+- Clarify in the README that the function-based callbacks (`video_frame_callback` / `audio_frame_callback`) are the recommended API and that the class-based API (`video_processor_factory` / `audio_processor_factory` with `VideoProcessorBase` / `AudioProcessorBase` subclasses) — while still supported — is planned for removal in a future major release. Closes #1102.

--- a/changelog.d/20260518_162836_t.yic.yt_triage_issues_20260518.md
+++ b/changelog.d/20260518_162836_t.yic.yt_triage_issues_20260518.md
@@ -1,4 +1,4 @@
-### Changed
+### Chore
 
 - Document the `on_video_ended` / `on_audio_ended` callbacks (and the matching `VideoProcessorBase.on_ended()` / `AudioProcessorBase.on_ended()` hooks) as the recommended way to release per-session resources when a WebRTC session ends. Adds a "Cleanup on Stop" section to the README and the mkdocs tutorial, and expands the docstrings on the processor base classes to spell out when the hook fires and the threading caveat (it runs on aiortc's asyncio loop, not Streamlit's main thread). Closes #2406.
 

--- a/docs/examples/tutorial/05_cleanup.py
+++ b/docs/examples/tutorial/05_cleanup.py
@@ -1,0 +1,17 @@
+import streamlit as st
+from streamlit_webrtc import webrtc_streamer
+
+
+def video_frame_callback(frame):
+    return frame
+
+
+def on_video_ended():
+    st.session_state.pop("my_session_resource", None)
+
+
+webrtc_streamer(
+    key="example",
+    video_frame_callback=video_frame_callback,
+    on_video_ended=on_video_ended,
+)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -78,6 +78,18 @@ The callbacks are executed in forked threads different from the main one, so the
 * The `global` keyword does not work expectedly in the callbacks.
 * You have to care about thread-safety when accessing the same objects both from outside and inside the callbacks as stated in the section above.
 
+## Cleanup on Stop
+
+`webrtc_streamer()` accepts `on_video_ended` and `on_audio_ended` arguments — zero-argument callables that fire when the corresponding input media track ends (the user clicks "STOP", closes the page, or the connection drops). They are the recommended hook for tearing down per-session resources that the frame callbacks allocated, such as worker threads, model handles, file writers, queues, or `st.session_state` entries:
+
+```python title="app.py"
+--8<-- "./examples/tutorial/05_cleanup.py"
+```
+
+These callbacks run on `aiortc`'s asyncio loop — not Streamlit's main thread — so the same caveats as the frame callbacks apply: `st.*` calls do not work inside them, and shared state must be mutated in a thread-safe way (e.g. with a `threading.Lock`, a `queue`, or a `threading.Event`).
+
+When using the class-based API (`video_processor_factory` / `audio_processor_factory`), override `VideoProcessorBase.on_ended()` / `AudioProcessorBase.on_ended()` instead — they fire at the same lifecycle point.
+
 ## Ready for Production?
 
 When you're ready to deploy your app, see the [Deployment Guide](deployment.md) for:

--- a/streamlit_webrtc/models.py
+++ b/streamlit_webrtc/models.py
@@ -116,7 +116,16 @@ class VideoProcessorBase(ProcessorBase[av.VideoFrame]):
 
     def on_ended(self):
         """
-        A callback method which is called when the input track ends.
+        Called when the input track ends — i.e. when the user clicks "STOP",
+        closes the page, or the connection drops.
+
+        Override this to release per-session resources (worker threads,
+        model handles, file writers, queues, etc.) allocated by ``recv()``
+        or ``recv_queued()``.
+
+        This is invoked on aiortc's asyncio loop, not Streamlit's main
+        thread, so ``st.*`` calls do not work here and shared state must
+        be accessed in a thread-safe way.
         """
 
 
@@ -160,7 +169,16 @@ class AudioProcessorBase(ProcessorBase[av.AudioFrame]):
 
     def on_ended(self):
         """
-        A callback method which is called when the input track ends.
+        Called when the input track ends — i.e. when the user clicks "STOP",
+        closes the page, or the connection drops.
+
+        Override this to release per-session resources (worker threads,
+        model handles, file writers, queues, etc.) allocated by ``recv()``
+        or ``recv_queued()``.
+
+        This is invoked on aiortc's asyncio loop, not Streamlit's main
+        thread, so ``st.*`` calls do not work here and shared state must
+        be accessed in a thread-safe way.
         """
 
 


### PR DESCRIPTION
## Summary

Two doc-only fixes triaged as low-hanging fruit:

- **#2406** — `on_video_ended` / `on_audio_ended` (and the matching `VideoProcessorBase.on_ended()` / `AudioProcessorBase.on_ended()` hooks) are the canonical place to release per-session resources (worker threads, model handles, queues, `st.session_state` entries) when a WebRTC session ends, but neither the README nor any `pages/` example mentioned them. Added a "Cleanup on Stop" section to the README and the mkdocs tutorial with a minimal snippet and the threading caveat (the hook runs on aiortc's asyncio loop, not Streamlit's main thread), and expanded the processor-base docstrings accordingly.
- **#1102** — The README's old "Class-based callbacks" section just pointed at the v0.37 README. Reworded it to state that the function-based callbacks (`video_frame_callback` / `audio_frame_callback`) are the recommended API and that the class-based API is planned for removal in v1.0 (matching @whitphx's reply on the issue).

No code/behavior change; tests, ruff, and mypy stay green.

## Test plan

- [x] `uv run pre-commit run --files ...` (ruff, ruff-format, mypy) — passes
- [x] `uv run pytest tests/models_test.py` — passes
- [x] Eyeball the rendered README and `docs/tutorial.md` for placement / wording

Closes #2406.
Closes #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on_video_ended and on_audio_ended cleanup callbacks to release per-session resources when WebRTC tracks end.

* **Documentation**
  * Added a tutorial example demonstrating session cleanup.
  * Added "Cleanup on Stop" guidance and noted callbacks run on aiortc’s asyncio loop (st.* calls won’t work; use thread-safe updates).
  * Clarified preference for function-based callbacks; class-based API remains supported but planned for removal in v1.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->