### PR TITLE
feat(source): fire on_ended when the session ends (page close included)

### DIFF
--- a/changelog.d/20260519_084441_t.yic.yt_source_track_on_ended_1800.md
+++ b/changelog.d/20260519_084441_t.yic.yt_source_track_on_ended_1800.md
@@ -1,0 +1,3 @@
+### Added
+
+- `create_video_source_track()` and `create_audio_source_track()` now accept an `on_ended` callback that fires when the source track ends. The factory also installs a `SessionShutdownObserver` per cached source track, so closing the page (without first clicking "STOP") now stops the track and fires `on_ended` deterministically — previously the track survived page close with no notification to user code. `VideoSourceTrack` / `AudioSourceTrack` also gained an `"ended"` event hook (via aiortc's `MediaStreamTrack.on("ended", ...)`) for callers that construct the tracks directly without the factory. Closes #1800.

--- a/pages/14_programmable_source.py
+++ b/pages/14_programmable_source.py
@@ -1,4 +1,5 @@
 import fractions
+import logging
 import time
 
 import av
@@ -6,6 +7,8 @@ import cv2
 import numpy as np
 import streamlit as st
 from streamlit_webrtc import WebRtcMode, create_video_source_track, webrtc_streamer
+
+logger = logging.getLogger(__name__)
 
 thickness = st.slider("thickness", 1, 10, 3, 1)
 
@@ -40,8 +43,15 @@ def video_source_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFr
 fps = st.slider("fps", 1, 30, 30, 1)
 
 
+def on_source_ended():
+    logger.info("Source track ended; release per-session resources here.")
+
+
 video_source_track = create_video_source_track(
-    video_source_callback, key="video_source_track", fps=fps
+    video_source_callback,
+    key="video_source_track",
+    fps=fps,
+    on_ended=on_source_ended,
 )
 
 

--- a/streamlit_webrtc/factory.py
+++ b/streamlit_webrtc/factory.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional, Type, Union, overload
+from typing import Callable, Literal, Optional, Type, Union, overload
 
 import streamlit as st
 
@@ -25,6 +25,7 @@ from .process import (
     VideoProcessTrack,
 )
 from .relay import get_global_relay
+from .shutdown import SessionShutdownObserver
 from .source import (
     AudioSourceCallback,
     AudioSourceTrack,
@@ -188,14 +189,19 @@ def create_mix_track(
 
 
 _VIDEO_SOURCE_TRACK_CACHE_KEY_PREFIX = "__VIDEO_SOURCE_TRACK_CACHE__"
+_VIDEO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX = (
+    "__VIDEO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE__"
+)
 
 
 def create_video_source_track(
     callback: VideoSourceCallback,
     key: str,
     fps=30,
+    on_ended: Optional[Callable[[], None]] = None,
 ) -> VideoSourceTrack:
     cache_key = _VIDEO_SOURCE_TRACK_CACHE_KEY_PREFIX + key
+    observer_cache_key = _VIDEO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX + key
     if (
         cache_key in st.session_state
         and isinstance(st.session_state[cache_key], VideoSourceTrack)
@@ -206,12 +212,29 @@ def create_video_source_track(
         video_source_track._callback = callback
         video_source_track._fps = fps
     else:
+        # The previous observer (if any) is bound to a now-stopped track; stop
+        # it before installing a fresh one so its polling thread isn't leaked
+        # for the rest of the session.
+        old_observer = st.session_state.get(observer_cache_key)
+        if isinstance(old_observer, SessionShutdownObserver):
+            old_observer.stop()
+
         video_source_track = VideoSourceTrack(callback=callback, fps=fps)
         st.session_state[cache_key] = video_source_track
+        # Auto-stop on Streamlit session shutdown so the "ended" event (and
+        # any `on_ended` callback) fires deterministically even when the user
+        # closes the page without clicking the STOP button first.
+        st.session_state[observer_cache_key] = SessionShutdownObserver(
+            video_source_track.stop
+        )
+    video_source_track._on_ended_callback = on_ended
     return video_source_track
 
 
 _AUDIO_SOURCE_TRACK_CACHE_KEY_PREFIX = "__AUDIO_SOURCE_TRACK_CACHE__"
+_AUDIO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX = (
+    "__AUDIO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE__"
+)
 
 
 def create_audio_source_track(
@@ -219,8 +242,10 @@ def create_audio_source_track(
     key: str,
     sample_rate: int = 48000,
     ptime: float = 0.020,
+    on_ended: Optional[Callable[[], None]] = None,
 ) -> AudioSourceTrack:
     cache_key = _AUDIO_SOURCE_TRACK_CACHE_KEY_PREFIX + key
+    observer_cache_key = _AUDIO_SOURCE_TRACK_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX + key
     if (
         cache_key in st.session_state
         and isinstance(st.session_state[cache_key], AudioSourceTrack)
@@ -233,8 +258,16 @@ def create_audio_source_track(
         audio_source_track._ptime = ptime
         audio_source_track._samples_per_frame = int(sample_rate * ptime)
     else:
+        old_observer = st.session_state.get(observer_cache_key)
+        if isinstance(old_observer, SessionShutdownObserver):
+            old_observer.stop()
+
         audio_source_track = AudioSourceTrack(
             callback=callback, sample_rate=sample_rate, ptime=ptime
         )
         st.session_state[cache_key] = audio_source_track
+        st.session_state[observer_cache_key] = SessionShutdownObserver(
+            audio_source_track.stop
+        )
+    audio_source_track._on_ended_callback = on_ended
     return audio_source_track

--- a/streamlit_webrtc/source.py
+++ b/streamlit_webrtc/source.py
@@ -32,6 +32,8 @@ AudioSourceCallback = Callable[
 
 
 class VideoSourceTrack(MediaStreamTrack):
+    _on_ended_callback: Optional[Callable[[], None]]
+
     def __init__(self, callback: VideoSourceCallback, fps: Union[int, float]) -> None:
         super().__init__()
         self.kind = "video"
@@ -39,6 +41,17 @@ class VideoSourceTrack(MediaStreamTrack):
         self._fps = fps
         self._started_at: Optional[float] = None
         self._pts: Optional[int] = None
+        self._on_ended_callback = None
+        self.on("ended", self._fire_on_ended)
+
+    def _fire_on_ended(self) -> None:
+        cb = self._on_ended_callback
+        if cb is None:
+            return
+        try:
+            cb()
+        except Exception:
+            logger.exception("VideoSourceTrack: on_ended callback raised an exception")
 
     async def recv(self) -> av.frame.Frame:
         if self.readyState != "live":
@@ -81,6 +94,8 @@ class VideoSourceTrack(MediaStreamTrack):
 
 
 class AudioSourceTrack(MediaStreamTrack):
+    _on_ended_callback: Optional[Callable[[], None]]
+
     def __init__(
         self,
         callback: AudioSourceCallback,
@@ -100,6 +115,17 @@ class AudioSourceTrack(MediaStreamTrack):
         self._time_base = fractions.Fraction(1, self._sample_rate)
         self._started_at: Optional[float] = None
         self._pts: Optional[int] = None
+        self._on_ended_callback = None
+        self.on("ended", self._fire_on_ended)
+
+    def _fire_on_ended(self) -> None:
+        cb = self._on_ended_callback
+        if cb is None:
+            return
+        try:
+            cb()
+        except Exception:
+            logger.exception("AudioSourceTrack: on_ended callback raised an exception")
 
     async def recv(self) -> av.frame.Frame:
         if self.readyState != "live":

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -5,7 +5,7 @@ import av
 import numpy as np
 import pytest
 
-from streamlit_webrtc.source import AudioSourceTrack
+from streamlit_webrtc.source import AudioSourceTrack, VideoSourceTrack
 
 
 def _make_callback(sample_rate: int, samples_per_frame: int):
@@ -57,3 +57,46 @@ def test_audio_source_track_time_base_matches_sample_rate(sample_rate: int) -> N
 def test_audio_source_track_rejects_non_positive_sample_rate(sample_rate: int) -> None:
     with pytest.raises(ValueError, match="sample_rate"):
         AudioSourceTrack(callback=_make_callback(48000, 960), sample_rate=sample_rate)
+
+
+def _video_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+    buffer = np.zeros((4, 4, 3), dtype=np.uint8)
+    return av.VideoFrame.from_ndarray(buffer, format="bgr24")
+
+
+def test_video_source_track_fires_on_ended_on_stop() -> None:
+    """Regression test for
+    https://github.com/whitphx/streamlit-webrtc/issues/1800:
+    source tracks need a deterministic notification when the session ends.
+    """
+    track = VideoSourceTrack(callback=_video_callback, fps=30)
+
+    calls: list[int] = []
+    track._on_ended_callback = lambda: calls.append(1)
+
+    track.stop()
+
+    assert calls == [1]
+
+
+def test_audio_source_track_fires_on_ended_on_stop() -> None:
+    track = AudioSourceTrack(callback=_make_callback(48000, 960), sample_rate=48000)
+
+    calls: list[int] = []
+    track._on_ended_callback = lambda: calls.append(1)
+
+    track.stop()
+
+    assert calls == [1]
+
+
+def test_video_source_track_on_ended_exception_is_swallowed() -> None:
+    """A misbehaving on_ended must not propagate into aiortc's event loop."""
+    track = VideoSourceTrack(callback=_video_callback, fps=30)
+
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    track._on_ended_callback = boom
+
+    track.stop()


### PR DESCRIPTION
## Summary

Closes #1800.

`create_video_source_track()` / `create_audio_source_track()` now accept an `on_ended` callback that fires when the source track ends. The factory also installs a `SessionShutdownObserver` per cached source track, so closing the page (without first clicking **STOP**) now stops the track and fires `on_ended` — previously the upstream source track survived page close with no notification to user code.

For callers that construct `VideoSourceTrack` / `AudioSourceTrack` directly (no factory), the same notification is available via aiortc's `MediaStreamTrack.on(\"ended\", ...)` — the classes register an internal listener that calls `self._on_ended_callback` so user-registered `\"ended\"` handlers still work.

The existing `on_change` → `track.stop()` pattern in `pages/14_programmable_source.py` for STOP-click cleanup is unchanged; both teardown paths (STOP and page close) now converge on the new `on_ended` hook.

## Changes

- `streamlit_webrtc/source.py` — `VideoSourceTrack` / `AudioSourceTrack` gain `_on_ended_callback` and an internal `\"ended\"` listener that invokes it (with exception swallowing + log).
- `streamlit_webrtc/factory.py` — `create_video_source_track` / `create_audio_source_track` accept `on_ended`. New factory installs a `SessionShutdownObserver(track.stop)` cached in `st.session_state`; old observers are stopped when a stopped track is replaced.
- `pages/14_programmable_source.py` — demonstrates the new `on_ended` parameter.
- `tests/source_test.py` — three new regression tests: video / audio on_ended fires on `stop()`, exception in callback is swallowed.

## Test plan

- [x] `uv run pytest tests/` — 52 passed
- [x] `uv run pre-commit run --files ...` — ruff, ruff-format, mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source tracks now support `on_ended` callbacks to notify when a track ends.
  * Tracks are automatically stopped when the page closes, ensuring reliable callback invocation.

* **Bug Fixes**
  * Fixed issue where source tracks could persist after page close without notifying user code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->