### PR TITLE
Fix spurious 'callback is too slow' warning under loop jitter

### DIFF
--- a/changelog.d/20260527_114516_t.yic.yt_source_track_slow_callback_warning.md
+++ b/changelog.d/20260527_114516_t.yic.yt_source_track_slow_callback_warning.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `AudioSourceTrack` and `VideoSourceTrack` no longer spam "callback is too slow" warnings under normal asyncio scheduling jitter. The check used a cumulative wall-clock target, so any one-off scheduling delay (loop contention, GC, etc.) made the wait stay negative forever and produced a warning on every subsequent frame. Now the warning fires only when the user's callback itself exceeds its frame budget (`ptime` for audio, `1/fps` for video) and includes the measured runtime.

--- a/streamlit_webrtc/source.py
+++ b/streamlit_webrtc/source.py
@@ -65,23 +65,7 @@ class VideoSourceTrack(MediaStreamTrack):
         else:
             self._pts += int(VIDEO_CLOCK_RATE / self._fps)
 
-            # Time the callback itself, not the cumulative schedule slip:
-            # any one-off scheduling delay (loop contention, GC, the
-            # `_started_at` baseline being set early) makes the cumulative
-            # `wait` below stay negative forever, so it can't distinguish
-            # a slow callback from loop jitter.
-            callback_start = time.monotonic()
             frame = self._call_callback(self._pts, VIDEO_TIME_BASE)
-            callback_elapsed = time.monotonic() - callback_start
-            frame_budget = 1.0 / self._fps
-            if callback_elapsed > frame_budget:
-                logger.warning(
-                    "%s: Video frame callback is too slow "
-                    "(%.1f ms > frame budget %.1f ms).",
-                    self.__class__.__name__,
-                    callback_elapsed * 1000,
-                    frame_budget * 1000,
-                )
 
             wait = self._started_at + (self._pts / VIDEO_CLOCK_RATE) - time.monotonic()
             if wait < 0:
@@ -91,6 +75,9 @@ class VideoSourceTrack(MediaStreamTrack):
         return frame
 
     def _call_callback(self, pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+        # Per-call timing (not cumulative wall-clock drift): one late frame
+        # mustn't keep tripping the warning on subsequent fast calls.
+        callback_start = time.monotonic()
         try:
             frame = self._callback(pts, time_base)
         except Exception as exc:
@@ -101,6 +88,17 @@ class VideoSourceTrack(MediaStreamTrack):
                 exc_info=True,
             )
             raise
+        callback_elapsed = time.monotonic() - callback_start
+
+        frame_budget = 1.0 / self._fps
+        if callback_elapsed > frame_budget:
+            logger.warning(
+                "%s: Video frame callback is too slow "
+                "(%.1f ms > frame budget %.1f ms).",
+                self.__class__.__name__,
+                callback_elapsed * 1000,
+                frame_budget * 1000,
+            )
 
         frame.pts = pts
         frame.time_base = time_base
@@ -153,21 +151,7 @@ class AudioSourceTrack(MediaStreamTrack):
         else:
             self._pts += self._samples_per_frame
 
-            # Time the callback itself, not the cumulative schedule slip:
-            # any one-off scheduling delay (loop contention, GC, the
-            # `_started_at` baseline being set early) makes the cumulative
-            # `wait` below stay negative forever, so it can't distinguish
-            # a slow callback from loop jitter.
-            callback_start = time.monotonic()
             frame = self._call_callback(self._pts, self._time_base)
-            callback_elapsed = time.monotonic() - callback_start
-            if callback_elapsed > self._ptime:
-                logger.warning(
-                    "%s: Audio frame callback is too slow (%.1f ms > ptime %.1f ms).",
-                    self.__class__.__name__,
-                    callback_elapsed * 1000,
-                    self._ptime * 1000,
-                )
 
             wait = self._started_at + (self._pts / self._sample_rate) - time.monotonic()
             if wait < 0:
@@ -177,6 +161,9 @@ class AudioSourceTrack(MediaStreamTrack):
         return frame
 
     def _call_callback(self, pts: int, time_base: fractions.Fraction) -> av.AudioFrame:
+        # Per-call timing (not cumulative wall-clock drift): one late frame
+        # mustn't keep tripping the warning on subsequent fast calls.
+        callback_start = time.monotonic()
         try:
             frame = self._callback(pts, time_base)
         except Exception as exc:
@@ -187,6 +174,15 @@ class AudioSourceTrack(MediaStreamTrack):
                 exc_info=True,
             )
             raise
+        callback_elapsed = time.monotonic() - callback_start
+
+        if callback_elapsed > self._ptime:
+            logger.warning(
+                "%s: Audio frame callback is too slow (%.1f ms > ptime %.1f ms).",
+                self.__class__.__name__,
+                callback_elapsed * 1000,
+                self._ptime * 1000,
+            )
 
         frame.pts = pts
         frame.time_base = time_base

--- a/streamlit_webrtc/source.py
+++ b/streamlit_webrtc/source.py
@@ -65,14 +65,26 @@ class VideoSourceTrack(MediaStreamTrack):
         else:
             self._pts += int(VIDEO_CLOCK_RATE / self._fps)
 
+            # Time the callback itself, not the cumulative schedule slip:
+            # any one-off scheduling delay (loop contention, GC, the
+            # `_started_at` baseline being set early) makes the cumulative
+            # `wait` below stay negative forever, so it can't distinguish
+            # a slow callback from loop jitter.
+            callback_start = time.monotonic()
             frame = self._call_callback(self._pts, VIDEO_TIME_BASE)
+            callback_elapsed = time.monotonic() - callback_start
+            frame_budget = 1.0 / self._fps
+            if callback_elapsed > frame_budget:
+                logger.warning(
+                    "%s: Video frame callback is too slow "
+                    "(%.1f ms > frame budget %.1f ms).",
+                    self.__class__.__name__,
+                    callback_elapsed * 1000,
+                    frame_budget * 1000,
+                )
 
             wait = self._started_at + (self._pts / VIDEO_CLOCK_RATE) - time.monotonic()
             if wait < 0:
-                logger.warning(
-                    "%s: Video frame callback is too slow.",
-                    self.__class__.__name__,
-                )
                 wait = 0
             await asyncio.sleep(wait)
 
@@ -141,14 +153,24 @@ class AudioSourceTrack(MediaStreamTrack):
         else:
             self._pts += self._samples_per_frame
 
+            # Time the callback itself, not the cumulative schedule slip:
+            # any one-off scheduling delay (loop contention, GC, the
+            # `_started_at` baseline being set early) makes the cumulative
+            # `wait` below stay negative forever, so it can't distinguish
+            # a slow callback from loop jitter.
+            callback_start = time.monotonic()
             frame = self._call_callback(self._pts, self._time_base)
+            callback_elapsed = time.monotonic() - callback_start
+            if callback_elapsed > self._ptime:
+                logger.warning(
+                    "%s: Audio frame callback is too slow (%.1f ms > ptime %.1f ms).",
+                    self.__class__.__name__,
+                    callback_elapsed * 1000,
+                    self._ptime * 1000,
+                )
 
             wait = self._started_at + (self._pts / self._sample_rate) - time.monotonic()
             if wait < 0:
-                logger.warning(
-                    "%s: Audio frame callback is too slow.",
-                    self.__class__.__name__,
-                )
                 wait = 0
             await asyncio.sleep(wait)
 

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -123,7 +123,10 @@ def _make_audio_callback_with_optional_delay(
     return callback
 
 
-def test_audio_source_track_warns_when_callback_is_slow(caplog) -> None:
+@pytest.mark.parametrize("slow_call_index", [1, 2])
+def test_audio_source_track_warns_when_callback_is_slow(
+    caplog, slow_call_index: int
+) -> None:
     ptime = 0.020
     sample_rate = 8000
     samples_per_frame = int(sample_rate * ptime)
@@ -131,9 +134,7 @@ def test_audio_source_track_warns_when_callback_is_slow(caplog) -> None:
     callback = _make_audio_callback_with_optional_delay(
         sample_rate=sample_rate,
         samples_per_frame=samples_per_frame,
-        # Second call (the first that's measured — the first frame
-        # establishes the baseline) blocks for 2× ptime.
-        delay_on_call={2: ptime * 2},
+        delay_on_call={slow_call_index: ptime * 2},
     )
     track = AudioSourceTrack(callback=callback, sample_rate=sample_rate, ptime=ptime)
 
@@ -148,7 +149,10 @@ def test_audio_source_track_warns_when_callback_is_slow(caplog) -> None:
     assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]
 
 
-def test_audio_source_track_does_not_warn_for_cumulative_drift(caplog) -> None:
+@pytest.mark.parametrize("slow_call_index", [1, 2])
+def test_audio_source_track_does_not_warn_for_cumulative_drift(
+    caplog, slow_call_index: int
+) -> None:
     """Regression: one slow callback must not spam warnings on subsequent calls.
 
     The pre-fix implementation compared a cumulative wall-clock target
@@ -165,8 +169,7 @@ def test_audio_source_track_does_not_warn_for_cumulative_drift(caplog) -> None:
     callback = _make_audio_callback_with_optional_delay(
         sample_rate=sample_rate,
         samples_per_frame=samples_per_frame,
-        # Only the second call is slow; calls 3-5 are instant.
-        delay_on_call={2: ptime * 2},
+        delay_on_call={slow_call_index: ptime * 2},
     )
     track = AudioSourceTrack(callback=callback, sample_rate=sample_rate, ptime=ptime)
 
@@ -195,12 +198,15 @@ def _make_video_callback_with_optional_delay(delay_on_call: dict[int, float]):
     return callback
 
 
-def test_video_source_track_warns_when_callback_is_slow(caplog) -> None:
+@pytest.mark.parametrize("slow_call_index", [1, 2])
+def test_video_source_track_warns_when_callback_is_slow(
+    caplog, slow_call_index: int
+) -> None:
     fps = 30
     frame_budget = 1.0 / fps
 
     callback = _make_video_callback_with_optional_delay(
-        delay_on_call={2: frame_budget * 2}
+        delay_on_call={slow_call_index: frame_budget * 2}
     )
     track = VideoSourceTrack(callback=callback, fps=fps)
 
@@ -215,12 +221,15 @@ def test_video_source_track_warns_when_callback_is_slow(caplog) -> None:
     assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]
 
 
-def test_video_source_track_does_not_warn_for_cumulative_drift(caplog) -> None:
+@pytest.mark.parametrize("slow_call_index", [1, 2])
+def test_video_source_track_does_not_warn_for_cumulative_drift(
+    caplog, slow_call_index: int
+) -> None:
     fps = 30
     frame_budget = 1.0 / fps
 
     callback = _make_video_callback_with_optional_delay(
-        delay_on_call={2: frame_budget * 2}
+        delay_on_call={slow_call_index: frame_budget * 2}
     )
     track = VideoSourceTrack(callback=callback, fps=fps)
 

--- a/tests/source_test.py
+++ b/tests/source_test.py
@@ -1,5 +1,7 @@
 import asyncio
 import fractions
+import logging
+import time
 
 import av
 import numpy as np
@@ -100,3 +102,134 @@ def test_video_source_track_on_ended_exception_is_swallowed() -> None:
     track._on_ended_callback = boom
 
     track.stop()
+
+
+def _make_audio_callback_with_optional_delay(
+    sample_rate: int, samples_per_frame: int, delay_on_call: dict[int, float]
+):
+    """Audio callback that sleeps `delay_on_call[n]` on the n-th invocation (1-based)."""
+    call_count = [0]
+
+    def callback(pts: int, time_base: fractions.Fraction) -> av.AudioFrame:
+        call_count[0] += 1
+        delay = delay_on_call.get(call_count[0], 0.0)
+        if delay > 0:
+            time.sleep(delay)
+        samples = np.zeros((1, samples_per_frame), dtype=np.int16)
+        frame = av.AudioFrame.from_ndarray(samples, format="s16", layout="mono")
+        frame.sample_rate = sample_rate
+        return frame
+
+    return callback
+
+
+def test_audio_source_track_warns_when_callback_is_slow(caplog) -> None:
+    ptime = 0.020
+    sample_rate = 8000
+    samples_per_frame = int(sample_rate * ptime)
+
+    callback = _make_audio_callback_with_optional_delay(
+        sample_rate=sample_rate,
+        samples_per_frame=samples_per_frame,
+        # Second call (the first that's measured — the first frame
+        # establishes the baseline) blocks for 2× ptime.
+        delay_on_call={2: ptime * 2},
+    )
+    track = AudioSourceTrack(callback=callback, sample_rate=sample_rate, ptime=ptime)
+
+    async def run():
+        await track.recv()
+        await track.recv()
+
+    with caplog.at_level(logging.WARNING, logger="streamlit_webrtc.source"):
+        asyncio.run(run())
+
+    slow_warnings = [r for r in caplog.records if "too slow" in r.getMessage()]
+    assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]
+
+
+def test_audio_source_track_does_not_warn_for_cumulative_drift(caplog) -> None:
+    """Regression: one slow callback must not spam warnings on subsequent calls.
+
+    The pre-fix implementation compared a cumulative wall-clock target
+    (``_started_at + N * ptime``) against ``time.monotonic()``; once the
+    wait went negative for any reason it stayed negative forever, so
+    every fast callback after a single slow one produced a "too slow"
+    warning. Per-frame timing isolates the diagnostic to the callback's
+    own runtime.
+    """
+    ptime = 0.020
+    sample_rate = 8000
+    samples_per_frame = int(sample_rate * ptime)
+
+    callback = _make_audio_callback_with_optional_delay(
+        sample_rate=sample_rate,
+        samples_per_frame=samples_per_frame,
+        # Only the second call is slow; calls 3-5 are instant.
+        delay_on_call={2: ptime * 2},
+    )
+    track = AudioSourceTrack(callback=callback, sample_rate=sample_rate, ptime=ptime)
+
+    async def run():
+        for _ in range(5):
+            await track.recv()
+
+    with caplog.at_level(logging.WARNING, logger="streamlit_webrtc.source"):
+        asyncio.run(run())
+
+    slow_warnings = [r for r in caplog.records if "too slow" in r.getMessage()]
+    assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]
+
+
+def _make_video_callback_with_optional_delay(delay_on_call: dict[int, float]):
+    call_count = [0]
+
+    def callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
+        call_count[0] += 1
+        delay = delay_on_call.get(call_count[0], 0.0)
+        if delay > 0:
+            time.sleep(delay)
+        buffer = np.zeros((4, 4, 3), dtype=np.uint8)
+        return av.VideoFrame.from_ndarray(buffer, format="bgr24")
+
+    return callback
+
+
+def test_video_source_track_warns_when_callback_is_slow(caplog) -> None:
+    fps = 30
+    frame_budget = 1.0 / fps
+
+    callback = _make_video_callback_with_optional_delay(
+        delay_on_call={2: frame_budget * 2}
+    )
+    track = VideoSourceTrack(callback=callback, fps=fps)
+
+    async def run():
+        await track.recv()
+        await track.recv()
+
+    with caplog.at_level(logging.WARNING, logger="streamlit_webrtc.source"):
+        asyncio.run(run())
+
+    slow_warnings = [r for r in caplog.records if "too slow" in r.getMessage()]
+    assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]
+
+
+def test_video_source_track_does_not_warn_for_cumulative_drift(caplog) -> None:
+    fps = 30
+    frame_budget = 1.0 / fps
+
+    callback = _make_video_callback_with_optional_delay(
+        delay_on_call={2: frame_budget * 2}
+    )
+    track = VideoSourceTrack(callback=callback, fps=fps)
+
+    async def run():
+        for _ in range(5):
+            await track.recv()
+
+    with caplog.at_level(logging.WARNING, logger="streamlit_webrtc.source"):
+        asyncio.run(run())
+
+    slow_warnings = [r for r in caplog.records if "too slow" in r.getMessage()]
+    assert len(slow_warnings) == 1, [r.getMessage() for r in slow_warnings]


### PR DESCRIPTION
## Summary

- `AudioSourceTrack.recv` / `VideoSourceTrack.recv` were using a cumulative wall-clock target (`_started_at + N * ptime` vs `time.monotonic()`) to decide whether the user's callback was too slow. Once that wait went negative for any reason — startup latency, a one-off GC pause, the asyncio loop briefly busy with aiortc work, even normal `asyncio.sleep` imprecision — the deficit persisted across every subsequent frame, producing a "callback is too slow" warning on every recv even though the user's code was instant.
- Replaced the cumulative check with per-frame timing: warn only when the user's callback itself exceeds its frame budget (`ptime` for audio, `1/fps` for video), and include the measured runtime in the message so it's actionable. The cumulative scheduling math is preserved for pacing (still clamped at `0`), it just no longer drives the warning.
- Surfaced while building #2487, where a trivially fast audio source callback (lock + 480-sample ringbuffer slice + AudioFrame construction) caused continuous warning spam.

## Test plan

- [x] New regression tests in `tests/source_test.py`:
  - `test_audio/video_source_track_warns_when_callback_is_slow` — a callback that sleeps 2× the frame budget triggers exactly one warning. Validates the warning still fires for genuinely slow callbacks.
  - `test_audio/video_source_track_does_not_warn_for_cumulative_drift` — a single slow call followed by 3 instant calls produces exactly one warning. **Reverted to the pre-fix `source.py` and confirmed this test fails (2 warnings instead of 1)**, then restored — it's a genuine regression test.
- [x] `uv run pytest tests/` — 65/65 pass locally.
- [x] `uv run ruff check / format --check / mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slow-callback detection for audio and video sources: warnings are now based on per-callback runtime versus the per-frame budget and include the measured duration and budget. Fixed repeated warnings caused by cumulative timing drift.

* **Tests**
  * Added deterministic tests ensuring a single warning is emitted when a callback exceeds the frame budget and no further warnings occur due to cumulative drift.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->