### PR TITLE
Refactor realtime sample's PCM buffer onto av.AudioFifo

### DIFF
--- a/changelog.d/20260528_154502_t.yic.yt_realtime_sample_pcm_audiofifo.md
+++ b/changelog.d/20260528_154502_t.yic.yt_realtime_sample_pcm_audiofifo.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Reimplement the OpenAI Realtime sample's PCM buffer (`pages/18_audio_chat_realtime.py`) on top of `av.AudioFifo` instead of a hand-rolled `np.concatenate` ring. Same external behavior (silence-padded fixed-size pulls), but the per-push O(n) recopy is gone and the partial-read edge cases ride on FFmpeg's `AVAudioFifo`.

--- a/pages/18_audio_chat_realtime.py
+++ b/pages/18_audio_chat_realtime.py
@@ -70,39 +70,44 @@ DEFAULT_INSTRUCTIONS = (
 
 
 class _PcmRingBuffer:
-    """Thread-safe int16 mono PCM ring with silence-padded pulls.
+    """Thread-safe int16 mono PCM buffer with silence-padded pulls.
 
-    The OpenAI session thread pushes irregular-sized chunks as they
-    arrive in ``response.output_audio.delta`` events; the aiortc source
-    callback pulls fixed-size frames at the playback cadence. If the
-    model hasn't sent enough audio yet the pull is padded with silence
-    so the source track stays on schedule.
+    Wraps :class:`av.AudioFifo` (FFmpeg's ``AVAudioFifo``) so the
+    producer/consumer split inherits FFmpeg's tested partial-read
+    semantics. The OpenAI session thread pushes irregular-sized chunks
+    as they arrive in ``response.output_audio.delta`` events; the
+    aiortc source callback pulls fixed-size frames at the playback
+    cadence. If the model hasn't sent enough audio yet the pull is
+    padded with silence so the source track stays on schedule.
     """
 
     def __init__(self) -> None:
-        self._buf: npt.NDArray[np.int16] = np.zeros(0, dtype=np.int16)
+        # PyAV's AudioFifo is not documented thread-safe, and we have a
+        # producer thread (OpenAI session) and consumer thread (aiortc
+        # source callback) hitting it concurrently.
+        self._fifo = av.AudioFifo()
         self._lock = threading.Lock()
 
     def push(self, samples: npt.NDArray[np.int16]) -> None:
+        frame = av.AudioFrame.from_ndarray(
+            samples.reshape(1, -1), format="s16", layout="mono"
+        )
+        frame.sample_rate = TARGET_SAMPLE_RATE
         with self._lock:
-            self._buf = np.concatenate([self._buf, samples])
+            self._fifo.write(frame)
 
     def pull(self, n: int) -> npt.NDArray[np.int16]:
         with self._lock:
-            available = len(self._buf)
-            if available >= n:
-                out = self._buf[:n].copy()
-                self._buf = self._buf[n:]
-                return out
-            out = np.zeros(n, dtype=np.int16)
-            if available:
-                out[:available] = self._buf
-                self._buf = np.zeros(0, dtype=np.int16)
-            return out
+            frame = self._fifo.read(n, partial=True)
+        out = np.zeros(n, dtype=np.int16)
+        if frame is not None:
+            available = frame.to_ndarray().reshape(-1)
+            out[: available.shape[0]] = available
+        return out
 
     def clear(self) -> None:
         with self._lock:
-            self._buf = np.zeros(0, dtype=np.int16)
+            self._fifo = av.AudioFifo()
 
 
 class RealtimeBridge:


### PR DESCRIPTION
## Summary

- `_PcmRingBuffer` in `pages/18_audio_chat_realtime.py` was hand-rolled on top of a growing `np.ndarray`, recopying the entire buffer on every producer push.
- Swap the internals to `av.AudioFifo` (FFmpeg's `AVAudioFifo`, already pulled in via PyAV) plus a `threading.Lock` and a 3-line silence-pad on underrun.
- Public interface (`push` / `pull` / `clear`) is unchanged, so the call sites in `RealtimeBridge` and `audio_source_callback` need no edits.

## Test plan

- [x] `uv run pytest tests/` — 61 passed
- [x] `uv run ruff format` / `ruff check` / `mypy` clean on the changed file
- [x] Ad-hoc end-to-end exercise of the new buffer (empty pull → all silence; partial pull; underrun pad; post-exhaust silence; `clear()`) — verified on local Python
- [ ] Speak into the sample app and confirm playback still matches pre-refactor behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Enhanced PCM audio buffer performance in the OpenAI Realtime sample by optimizing internal buffering mechanisms. The buffer now handles edge cases more efficiently while maintaining the same external behavior for audio padding and pull operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->