### PR TITLE
Add create_pcm_audio_source_track / PcmAudioSource

### DIFF
--- a/changelog.d/20260528_162102_t.yic.yt_pcm_audio_source_track.md
+++ b/changelog.d/20260528_162102_t.yic.yt_pcm_audio_source_track.md
@@ -1,0 +1,3 @@
+### Added
+
+- `create_pcm_audio_source_track(key, sample_rate, ptime) -> PcmAudioSource`: a higher-level source-track factory for samples that drive playback from an external streaming PCM producer (TTS / voice LLM / pre-buffered audio). The returned `PcmAudioSource` exposes a thread-safe `push(bytes | np.int16 ndarray)` for irregular producer chunks and `clear()` for barge-in, while internally pulling fixed-cadence s16-mono frames into a `track` you pass to `webrtc_streamer(source_audio_track=...)`. Underruns are silence-padded to keep the track on schedule. The realtime sample (`pages/18_audio_chat_realtime.py`) now uses this helper.

--- a/pages/18_audio_chat_realtime.py
+++ b/pages/18_audio_chat_realtime.py
@@ -4,15 +4,11 @@ The browser captures microphone audio. The server consumes every
 audio frame through ``create_audio_sink_track`` (push-based, no
 drop), resamples it to 24 kHz mono PCM16, and streams it to
 ``gpt-realtime`` over OpenAI's Realtime WebSocket. The model's spoken
-response arrives as 24 kHz PCM16 chunks, which are buffered and emitted
-back to the browser through ``create_audio_source_track``. Server-side
-VAD on OpenAI's side handles turn-taking and interruption.
-
-This page doubles as an end-to-end exercise of the ``sink_audio_track``
-+ ``source_audio_track`` pair (introduced in #2479) — the primitive
-that lets the input rate (browser mic, 48 kHz Opus) and the output
-rate (model response, 24 kHz PCM) run on independent clocks without
-the 1:1 frame coupling of ``audio_frame_callback``.
+response arrives as 24 kHz PCM16 chunks, pushed straight into a
+``PcmAudioSource`` whose track is wired to the browser via
+``source_audio_track=``. Server-side VAD on OpenAI's side handles
+turn-taking and interruption (a ``speech_started`` event clears the
+output buffer for barge-in).
 
 Setup:
 - ``pip install openai``
@@ -30,12 +26,12 @@ from typing import Optional
 
 import av
 import numpy as np
-import numpy.typing as npt
 import streamlit as st
 from streamlit_webrtc import (
+    PcmAudioSource,
     WebRtcMode,
     create_audio_sink_track,
-    create_audio_source_track,
+    create_pcm_audio_source_track,
     webrtc_streamer,
 )
 from streamlit_webrtc.shutdown import SessionShutdownObserver
@@ -49,7 +45,6 @@ logger = logging.getLogger(__name__)
 # transceiver.
 TARGET_SAMPLE_RATE = 24000
 SOURCE_PTIME = 0.020
-SOURCE_SAMPLES_PER_FRAME = int(TARGET_SAMPLE_RATE * SOURCE_PTIME)
 
 DEFAULT_MODEL = "gpt-realtime"
 DEFAULT_VOICE = "alloy"
@@ -69,42 +64,6 @@ DEFAULT_INSTRUCTIONS = (
 )
 
 
-class _PcmRingBuffer:
-    """Thread-safe int16 mono PCM ring with silence-padded pulls.
-
-    The OpenAI session thread pushes irregular-sized chunks as they
-    arrive in ``response.output_audio.delta`` events; the aiortc source
-    callback pulls fixed-size frames at the playback cadence. If the
-    model hasn't sent enough audio yet the pull is padded with silence
-    so the source track stays on schedule.
-    """
-
-    def __init__(self) -> None:
-        self._buf: npt.NDArray[np.int16] = np.zeros(0, dtype=np.int16)
-        self._lock = threading.Lock()
-
-    def push(self, samples: npt.NDArray[np.int16]) -> None:
-        with self._lock:
-            self._buf = np.concatenate([self._buf, samples])
-
-    def pull(self, n: int) -> npt.NDArray[np.int16]:
-        with self._lock:
-            available = len(self._buf)
-            if available >= n:
-                out = self._buf[:n].copy()
-                self._buf = self._buf[n:]
-                return out
-            out = np.zeros(n, dtype=np.int16)
-            if available:
-                out[:available] = self._buf
-                self._buf = np.zeros(0, dtype=np.int16)
-            return out
-
-    def clear(self) -> None:
-        with self._lock:
-            self._buf = np.zeros(0, dtype=np.int16)
-
-
 class RealtimeBridge:
     """Owns the OpenAI Realtime WebSocket and the I/O bridges.
 
@@ -117,26 +76,26 @@ class RealtimeBridge:
       :meth:`push_input` — bytes hop onto the session loop's queue via
       ``call_soon_threadsafe``.
     * **Output** (session thread → aiortc loop): the session thread
-      decodes ``response.output_audio.delta`` chunks and writes them
-      into a :class:`_PcmRingBuffer`; the source callback pulls
-      fixed-size slices each tick.
+      decodes ``response.output_audio.delta`` chunks and pushes them
+      into the :class:`PcmAudioSource` passed in at construction time.
     """
 
     def __init__(
         self,
         api_key: str,
+        pcm_out: PcmAudioSource,
         model: str = DEFAULT_MODEL,
         voice: str = DEFAULT_VOICE,
         instructions: str = DEFAULT_INSTRUCTIONS,
     ) -> None:
         self._api_key = api_key
+        self._pcm_out = pcm_out
         self._model = model
         self._voice = voice
         self._instructions = instructions
 
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._input_queue: Optional["asyncio.Queue[bytes]"] = None
-        self._output_buffer = _PcmRingBuffer()
         # av.AudioResampler buffers internally, so calling resample() on
         # each input frame yields zero-or-more output frames at the
         # target rate. The instance is stateful and must not be shared
@@ -187,7 +146,7 @@ class RealtimeBridge:
         if thread is not None:
             thread.join(timeout=3.0)
         self._thread = None
-        self._output_buffer.clear()
+        self._pcm_out.clear()
 
     # ------------------------------------------------------------------
     # Called from aiortc loop
@@ -207,9 +166,6 @@ class RealtimeBridge:
             except RuntimeError:
                 # Loop just shut down underneath us; drop the frame.
                 return
-
-    def pull_output(self, n_samples: int) -> np.ndarray:
-        return self._output_buffer.pull(n_samples)
 
     # ------------------------------------------------------------------
     # Status (for the UI)
@@ -302,14 +258,12 @@ class RealtimeBridge:
         async for event in conn:
             etype = getattr(event, "type", "")
             if etype == "response.output_audio.delta":
-                pcm = base64.b64decode(event.delta)
-                samples = np.frombuffer(pcm, dtype=np.int16)
-                self._output_buffer.push(samples)
+                self._pcm_out.push(base64.b64decode(event.delta))
             elif etype == "input_audio_buffer.speech_started":
                 # Barge-in: drop any pending model audio so the user's
                 # new utterance isn't talked over while we wait for the
                 # next response.
-                self._output_buffer.clear()
+                self._pcm_out.clear()
             elif etype == "response.output_audio_transcript.delta":
                 with self._state_lock:
                     self._assistant_transcript += getattr(event, "delta", "") or ""
@@ -378,6 +332,13 @@ BRIDGE_KEY = "openai_realtime_bridge"
 BRIDGE_SHUTDOWN_OBSERVER_KEY = "openai_realtime_bridge_shutdown_observer"
 
 
+pcm_out = create_pcm_audio_source_track(
+    key="openai_realtime_out",
+    sample_rate=TARGET_SAMPLE_RATE,
+    ptime=SOURCE_PTIME,
+)
+
+
 def _get_or_make_bridge() -> RealtimeBridge:
     bridge = st.session_state.get(BRIDGE_KEY)
     # Reconfigure on any setting change by tearing down and rebuilding;
@@ -391,7 +352,11 @@ def _get_or_make_bridge() -> RealtimeBridge:
         if isinstance(old_observer, SessionShutdownObserver):
             old_observer.stop()
         bridge = RealtimeBridge(
-            api_key=api_key, model=model, voice=voice, instructions=instructions
+            api_key=api_key,
+            pcm_out=pcm_out,
+            model=model,
+            voice=voice,
+            instructions=instructions,
         )
         st.session_state[BRIDGE_KEY] = bridge
         st.session_state["_bridge_config"] = config
@@ -408,25 +373,8 @@ def audio_sink_callback(frame: av.AudioFrame) -> None:
     bridge.push_input(frame)
 
 
-def audio_source_callback(pts, time_base) -> av.AudioFrame:
-    samples = bridge.pull_output(SOURCE_SAMPLES_PER_FRAME)
-    # av.AudioFrame.from_ndarray expects shape (channels, samples) for
-    # non-planar `s16` mono.
-    frame = av.AudioFrame.from_ndarray(
-        samples.reshape(1, -1), format="s16", layout="mono"
-    )
-    frame.sample_rate = TARGET_SAMPLE_RATE
-    return frame
-
-
 audio_sink_track = create_audio_sink_track(
     audio_sink_callback, key="openai_realtime_in"
-)
-audio_source_track = create_audio_source_track(
-    audio_source_callback,
-    key="openai_realtime_out",
-    sample_rate=TARGET_SAMPLE_RATE,
-    ptime=SOURCE_PTIME,
 )
 
 
@@ -438,7 +386,7 @@ def on_change() -> None:
     if stopped:
         bridge.stop()
         audio_sink_track.stop()
-        audio_source_track.stop()
+        pcm_out.track.stop()
 
 
 webrtc_streamer(
@@ -446,7 +394,7 @@ webrtc_streamer(
     mode=WebRtcMode.SENDRECV,
     media_stream_constraints={"audio": True, "video": False},
     sink_audio_track=audio_sink_track,
-    source_audio_track=audio_source_track,
+    source_audio_track=pcm_out.track,
     on_change=on_change,
 )
 
@@ -477,6 +425,6 @@ render_live_status()
 st.caption(
     "Audio path: browser mic → 48 kHz Opus → aiortc decode → "
     "`audio_sink_track` callback → resample 24 kHz s16 → OpenAI WS. "
-    "Model audio: WS → 24 kHz s16 PCM ring → `audio_source_track` "
-    "callback → aiortc Opus encode → browser speaker."
+    "Model audio: WS → `PcmAudioSource.push` → aiortc Opus encode → "
+    "browser speaker."
 )

--- a/streamlit_webrtc/__init__.py
+++ b/streamlit_webrtc/__init__.py
@@ -25,11 +25,13 @@ from .factory import (
     create_audio_sink_track,
     create_audio_source_track,
     create_mix_track,
+    create_pcm_audio_source_track,
     create_process_track,
     create_video_sink_track,
     create_video_source_track,
 )
 from .mix import MediaStreamMixTrack, MixerCallback
+from .pcm_source import PcmAudioSource
 from .sink import (
     AudioSinkCallback,
     AudioSinkTrack,
@@ -94,6 +96,8 @@ __all__ = [
     "AudioSinkCallback",
     "create_video_source_track",
     "create_audio_source_track",
+    "create_pcm_audio_source_track",
+    "PcmAudioSource",
     "create_video_sink_track",
     "create_audio_sink_track",
     "WebRtcMode",

--- a/streamlit_webrtc/factory.py
+++ b/streamlit_webrtc/factory.py
@@ -16,6 +16,7 @@ from .models import (
     VideoProcessorFactory,
     VideoProcessorT,
 )
+from .pcm_source import PcmAudioSource
 from .process import (
     AsyncAudioProcessTrack,
     AsyncMediaProcessTrack,
@@ -309,6 +310,51 @@ def create_audio_sink_track(
         )
     audio_sink_track._on_ended_callback = on_ended
     return audio_sink_track
+
+
+_PCM_AUDIO_SOURCE_CACHE_KEY_PREFIX = "__PCM_AUDIO_SOURCE_CACHE__"
+_PCM_AUDIO_SOURCE_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX = (
+    "__PCM_AUDIO_SOURCE_SHUTDOWN_OBSERVER_CACHE__"
+)
+
+
+def create_pcm_audio_source_track(
+    *,
+    key: str,
+    sample_rate: int,
+    ptime: float = 0.020,
+) -> PcmAudioSource:
+    """Create a source track that plays s16-mono PCM pushed from any thread.
+
+    Mirrors :func:`create_audio_source_track`'s key-based session cache so
+    the buffer survives Streamlit reruns and queued audio isn't lost.
+
+    The returned :class:`PcmAudioSource` exposes ``track`` (pass to
+    ``webrtc_streamer(source_audio_track=...)``), :meth:`PcmAudioSource.push`
+    (append PCM bytes / int16 ndarray, callable from any thread), and
+    :meth:`PcmAudioSource.clear` (drop buffered samples, e.g. on barge-in).
+    """
+    cache_key = _PCM_AUDIO_SOURCE_CACHE_KEY_PREFIX + key
+    observer_cache_key = _PCM_AUDIO_SOURCE_SHUTDOWN_OBSERVER_CACHE_KEY_PREFIX + key
+    existing = st.session_state.get(cache_key)
+    if (
+        isinstance(existing, PcmAudioSource)
+        and existing.track.readyState == "live"
+        and existing.sample_rate == sample_rate
+        and existing.ptime == ptime
+    ):
+        return existing
+
+    old_observer = st.session_state.get(observer_cache_key)
+    if isinstance(old_observer, SessionShutdownObserver):
+        old_observer.stop()
+
+    pcm_source = PcmAudioSource(sample_rate=sample_rate, ptime=ptime)
+    st.session_state[cache_key] = pcm_source
+    st.session_state[observer_cache_key] = SessionShutdownObserver(
+        pcm_source.track.stop
+    )
+    return pcm_source
 
 
 def create_audio_source_track(

--- a/streamlit_webrtc/factory.py
+++ b/streamlit_webrtc/factory.py
@@ -348,6 +348,11 @@ def create_pcm_audio_source_track(
     old_observer = st.session_state.get(observer_cache_key)
     if isinstance(old_observer, SessionShutdownObserver):
         old_observer.stop()
+    # Stopping the observer doesn't fire its callback, so if the cache held a
+    # PcmAudioSource whose track is still live (param change between reruns),
+    # stop it explicitly to avoid leaking the underlying media track.
+    if isinstance(existing, PcmAudioSource) and existing.track.readyState == "live":
+        existing.track.stop()
 
     pcm_source = PcmAudioSource(sample_rate=sample_rate, ptime=ptime)
     st.session_state[cache_key] = pcm_source

--- a/streamlit_webrtc/pcm_source.py
+++ b/streamlit_webrtc/pcm_source.py
@@ -1,0 +1,110 @@
+"""Streamed-PCM source track with a thread-safe push/clear interface."""
+
+from __future__ import annotations
+
+import fractions
+import threading
+from typing import Union
+
+import av
+import numpy as np
+import numpy.typing as npt
+
+from .source import AUDIO_PTIME, AudioSourceTrack
+
+
+class PcmAudioSource:
+    """Streamed-PCM source track with a thread-safe push/clear interface.
+
+    Backs an :class:`AudioSourceTrack` with an internal :class:`av.AudioFifo`
+    so an arbitrary producer (background thread, async session, WebSocket
+    handler) can push s16-mono PCM samples at irregular cadence while the
+    aiortc media loop pulls fixed-size frames at ``ptime``. Underruns are
+    padded with silence to keep the track on schedule.
+
+    The track is only s16 mono for now — the common shape for realtime
+    audio APIs (TTS, voice LLMs, ASR echo). Stereo / float layouts would
+    be a future extension.
+    """
+
+    track: AudioSourceTrack
+
+    def __init__(self, *, sample_rate: int, ptime: float = AUDIO_PTIME) -> None:
+        if sample_rate <= 0:
+            raise ValueError(
+                f"sample_rate must be a positive integer, got {sample_rate}"
+            )
+        if ptime <= 0:
+            raise ValueError(f"ptime must be a positive number, got {ptime}")
+        self._sample_rate = sample_rate
+        self._ptime = ptime
+        self._samples_per_frame = int(sample_rate * ptime)
+        # PyAV's AudioFifo isn't documented thread-safe and we have a
+        # producer (caller's thread) and consumer (aiortc media loop)
+        # touching it concurrently.
+        self._fifo = av.AudioFifo()
+        self._lock = threading.Lock()
+        self.track = AudioSourceTrack(
+            callback=self._source_callback,
+            sample_rate=sample_rate,
+            ptime=ptime,
+        )
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    @property
+    def ptime(self) -> float:
+        return self._ptime
+
+    def push(
+        self, pcm: Union[bytes, bytearray, memoryview, npt.NDArray[np.int16]]
+    ) -> None:
+        """Append PCM samples to the playback queue.
+
+        ``bytes`` / ``bytearray`` / ``memoryview`` inputs are interpreted as
+        little-endian s16 mono samples (the universal wire shape). A numpy
+        array must be 1-D and have dtype ``int16``.
+        """
+        if isinstance(pcm, (bytes, bytearray, memoryview)):
+            samples = np.frombuffer(pcm, dtype=np.int16)
+        else:
+            samples = np.asarray(pcm)
+            if samples.dtype != np.int16:
+                raise ValueError(
+                    f"pcm ndarray must have dtype int16, got {samples.dtype}"
+                )
+            if samples.ndim != 1:
+                raise ValueError(
+                    f"pcm ndarray must be 1-D mono, got shape {samples.shape}"
+                )
+        if samples.size == 0:
+            return
+        frame = av.AudioFrame.from_ndarray(
+            samples.reshape(1, -1), format="s16", layout="mono"
+        )
+        frame.sample_rate = self._sample_rate
+        with self._lock:
+            self._fifo.write(frame)
+
+    def clear(self) -> None:
+        """Drop all buffered samples (e.g. on barge-in)."""
+        with self._lock:
+            # AudioFifo has no in-place reset; the cheapest equivalent
+            # is a fresh instance.
+            self._fifo = av.AudioFifo()
+
+    def _source_callback(
+        self, pts: int, time_base: fractions.Fraction
+    ) -> av.AudioFrame:
+        n = self._samples_per_frame
+        with self._lock:
+            frame = self._fifo.read(n, partial=True)
+        out = np.zeros((1, n), dtype=np.int16)
+        if frame is not None:
+            available = frame.to_ndarray()
+            out[:, : available.shape[1]] = available
+        result = av.AudioFrame.from_ndarray(out, format="s16", layout="mono")
+        result.sample_rate = self._sample_rate
+        return result

--- a/streamlit_webrtc/pcm_source.py
+++ b/streamlit_webrtc/pcm_source.py
@@ -36,9 +36,15 @@ class PcmAudioSource:
             )
         if ptime <= 0:
             raise ValueError(f"ptime must be a positive number, got {ptime}")
+        samples_per_frame = int(sample_rate * ptime)
+        if samples_per_frame <= 0:
+            raise ValueError(
+                f"ptime ({ptime}) is too small for sample_rate ({sample_rate}); "
+                "int(sample_rate * ptime) must be >= 1"
+            )
         self._sample_rate = sample_rate
         self._ptime = ptime
-        self._samples_per_frame = int(sample_rate * ptime)
+        self._samples_per_frame = samples_per_frame
         # PyAV's AudioFifo isn't documented thread-safe and we have a
         # producer (caller's thread) and consumer (aiortc media loop)
         # touching it concurrently.

--- a/tests/pcm_source_test.py
+++ b/tests/pcm_source_test.py
@@ -1,0 +1,145 @@
+import asyncio
+import threading
+from typing import cast
+
+import av
+import numpy as np
+import pytest
+
+from streamlit_webrtc.pcm_source import PcmAudioSource
+
+
+def _consume(source: PcmAudioSource, n_frames: int) -> np.ndarray:
+    """Pull ``n_frames`` audio frames from the track and return their samples."""
+
+    async def run() -> list[av.AudioFrame]:
+        return [cast(av.AudioFrame, await source.track.recv()) for _ in range(n_frames)]
+
+    frames = asyncio.run(run())
+    return np.concatenate([f.to_ndarray().reshape(-1) for f in frames])
+
+
+def test_push_bytes_plays_back_in_order() -> None:
+    src = PcmAudioSource(sample_rate=8000, ptime=0.020)
+    samples_per_frame = int(8000 * 0.020)  # 160
+
+    pcm = np.arange(1, samples_per_frame * 2 + 1, dtype=np.int16).tobytes()
+    src.push(pcm)
+
+    out = _consume(src, 2)
+    expected = np.arange(1, samples_per_frame * 2 + 1, dtype=np.int16)
+    assert np.array_equal(out, expected)
+
+
+def test_push_ndarray_plays_back_in_order() -> None:
+    src = PcmAudioSource(sample_rate=8000, ptime=0.020)
+    samples_per_frame = int(8000 * 0.020)
+
+    arr = np.arange(1, samples_per_frame * 3 + 1, dtype=np.int16)
+    src.push(arr)
+
+    out = _consume(src, 3)
+    assert np.array_equal(out, arr)
+
+
+def test_underrun_is_silence_padded() -> None:
+    src = PcmAudioSource(sample_rate=8000, ptime=0.020)
+    samples_per_frame = int(8000 * 0.020)
+
+    # Push half a frame; consume two full frames.
+    partial = np.arange(1, samples_per_frame // 2 + 1, dtype=np.int16)
+    src.push(partial)
+
+    out = _consume(src, 2)
+    assert out.shape == (samples_per_frame * 2,)
+    # First half matches what we pushed; the rest is silence.
+    assert np.array_equal(out[: partial.size], partial)
+    assert (out[partial.size :] == 0).all()
+
+
+def test_clear_drops_buffered_samples() -> None:
+    src = PcmAudioSource(sample_rate=8000, ptime=0.020)
+    samples_per_frame = int(8000 * 0.020)
+
+    src.push(np.arange(1, samples_per_frame * 4 + 1, dtype=np.int16))
+    src.clear()
+
+    out = _consume(src, 1)
+    assert (out == 0).all()
+
+
+def test_frame_metadata_matches_configured_rate() -> None:
+    src = PcmAudioSource(sample_rate=16000, ptime=0.020)
+
+    src.push(np.zeros(320, dtype=np.int16))
+
+    async def run():
+        return await src.track.recv()
+
+    frame = asyncio.run(run())
+    assert frame.sample_rate == 16000
+    assert frame.format.name == "s16"
+    assert frame.layout.name == "mono"
+    assert frame.samples == int(16000 * 0.020)
+
+
+def test_push_rejects_non_int16_ndarray() -> None:
+    src = PcmAudioSource(sample_rate=8000)
+    with pytest.raises(ValueError, match="int16"):
+        src.push(np.zeros(160, dtype=np.float32))
+
+
+def test_push_rejects_multidim_ndarray() -> None:
+    src = PcmAudioSource(sample_rate=8000)
+    with pytest.raises(ValueError, match="1-D"):
+        src.push(np.zeros((2, 160), dtype=np.int16))
+
+
+def test_push_empty_is_noop() -> None:
+    src = PcmAudioSource(sample_rate=8000, ptime=0.020)
+    src.push(b"")
+    src.push(np.zeros(0, dtype=np.int16))
+
+    out = _consume(src, 1)
+    assert (out == 0).all()
+
+
+@pytest.mark.parametrize("sample_rate", [0, -1])
+def test_rejects_non_positive_sample_rate(sample_rate: int) -> None:
+    with pytest.raises(ValueError, match="sample_rate"):
+        PcmAudioSource(sample_rate=sample_rate)
+
+
+@pytest.mark.parametrize("ptime", [0.0, -0.020])
+def test_rejects_non_positive_ptime(ptime: float) -> None:
+    with pytest.raises(ValueError, match="ptime"):
+        PcmAudioSource(sample_rate=8000, ptime=ptime)
+
+
+def test_push_is_thread_safe() -> None:
+    """Concurrent producers must not corrupt the FIFO (total sample count
+    matches the sum of pushed lengths)."""
+    src = PcmAudioSource(sample_rate=48000, ptime=0.020)
+
+    per_thread = 5000
+    n_threads = 8
+
+    def producer() -> None:
+        # Each thread pushes its own block of distinct samples.
+        src.push(np.ones(per_thread, dtype=np.int16))
+
+    threads = [threading.Thread(target=producer) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Consume enough frames to drain everything we pushed.
+    samples_per_frame = int(48000 * 0.020)  # 960
+    total_pushed = per_thread * n_threads
+    frames_needed = (total_pushed + samples_per_frame - 1) // samples_per_frame
+    out = _consume(src, frames_needed)
+
+    # Every pushed sample is a 1, and we drained at least that many; the
+    # leading `total_pushed` samples must all be 1.
+    assert (out[:total_pushed] == 1).all()

--- a/tests/pcm_source_test.py
+++ b/tests/pcm_source_test.py
@@ -116,6 +116,12 @@ def test_rejects_non_positive_ptime(ptime: float) -> None:
         PcmAudioSource(sample_rate=8000, ptime=ptime)
 
 
+def test_rejects_ptime_smaller_than_one_sample() -> None:
+    # 8000 * 0.0001 == 0.8, floors to 0 → degenerate frame size.
+    with pytest.raises(ValueError, match="too small"):
+        PcmAudioSource(sample_rate=8000, ptime=0.0001)
+
+
 def test_push_is_thread_safe() -> None:
     """Concurrent producers must not corrupt the FIFO (total sample count
     matches the sum of pushed lengths)."""
@@ -125,7 +131,6 @@ def test_push_is_thread_safe() -> None:
     n_threads = 8
 
     def producer() -> None:
-        # Each thread pushes its own block of distinct samples.
         src.push(np.ones(per_thread, dtype=np.int16))
 
     threads = [threading.Thread(target=producer) for _ in range(n_threads)]


### PR DESCRIPTION
## Summary

New higher-level source-track factory for samples that drive playback from an external streaming PCM producer (TTS, voice LLM, pre-buffered audio).

- `create_pcm_audio_source_track(key, sample_rate, ptime) -> PcmAudioSource`
- `PcmAudioSource.push(bytes | np.int16 ndarray)` — thread-safe, accepts irregular producer chunks (`bytes` interpreted as little-endian s16 mono, the universal wire shape)
- `PcmAudioSource.clear()` — drop buffered samples (for barge-in)
- `PcmAudioSource.track` — pass to `webrtc_streamer(source_audio_track=...)`
- Underruns are silence-padded to keep the track on schedule
- Key-based session-state caching mirrors `create_audio_source_track` so the buffer survives Streamlit reruns

Internals are an `av.AudioFifo` (FFmpeg's `AVAudioFifo`, already pulled in via PyAV) plus a `threading.Lock` and a 3-line silence-pad on the consumer side. The library stays service-agnostic — no OpenAI / TTS / API-specific shape leaks into the public API.

The OpenAI Realtime sample (`pages/18_audio_chat_realtime.py`) is ported to the new helper as the first consumer: its hand-rolled `_PcmRingBuffer` class, `pull_output` indirection, and bespoke `audio_source_callback` / `create_audio_source_track` wiring collapse to a single `create_pcm_audio_source_track(...)` call and `pcm_out.push` / `pcm_out.clear` in the OpenAI recv loop.

## Test plan

- [x] `uv run pytest tests/` — 74 passed (61 prior + 13 new `pcm_source_test.py` cases covering: bytes / ndarray push, underrun silence-pad, clear, frame metadata, dtype / shape validation, empty push, sample_rate / ptime validation, concurrent producers)
- [x] `uv run ruff format` / `ruff check` / `mypy` clean
- [ ] Speak into `pages/18_audio_chat_realtime.py` and confirm playback + barge-in still behave the same end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a thread-safe PCM audio source with push-based streaming and a clear (barge-in) capability for flexible, low-latency audio input.
  * Realtime audio chat updated to use the new direct PCM audio source for improved streaming and simpler audio path.

* **Tests**
  * Added comprehensive tests for playback order, silence-padding, input validation, concurrency/thread-safety, and metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/whitphx/streamlit-webrtc/pull/2494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->