### PR TITLE
[codex] fix shutdown observer stop race

### DIFF
--- a/changelog.d/20260617_114540_whitphx_shutdown-observer-race.md
+++ b/changelog.d/20260617_114540_whitphx_shutdown-observer-race.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a race in shutdown observer cleanup that could raise `AttributeError: 'NoneType' object has no attribute 'is_alive'` when a WebRTC worker stops from overlapping shutdown paths.

--- a/streamlit_webrtc/shutdown.py
+++ b/streamlit_webrtc/shutdown.py
@@ -34,10 +34,12 @@ class SessionShutdownObserver:
 
     _polling_thread: Union[threading.Thread, None]
     _polling_thread_stop_event: threading.Event
+    _stop_lock: threading.Lock
 
     def __init__(self, callback: Callback) -> None:
         self._polling_thread = None
         self._polling_thread_stop_event = threading.Event()
+        self._stop_lock = threading.Lock()
         self._callback = callback
 
         session_info = get_this_session_info()
@@ -117,17 +119,20 @@ class SessionShutdownObserver:
             logger.exception("Error in shutdown callback: %s", e)
 
     def stop(self, timeout: float = 1.0) -> None:
-        if self._polling_thread:
+        with self._stop_lock:
+            polling_thread = self._polling_thread
+            self._polling_thread = None
             self._polling_thread_stop_event.set()
 
-            # 🔑 FIX: do not join current thread
-            if threading.current_thread() is not self._polling_thread:
-                self._polling_thread.join(timeout=timeout)
-                if self._polling_thread.is_alive():
-                    logger.warning("ShutdownPolling thread did not exit cleanly")
-                else:
-                    logger.debug("ShutdownPolling thread stopped cleanly")
-            else:
-                logger.debug("Stop called from polling thread itself, skipping join.")
+        if polling_thread is None:
+            return
 
-            self._polling_thread = None
+        if threading.current_thread() is polling_thread:
+            logger.debug("Stop called from polling thread itself, skipping join.")
+            return
+
+        polling_thread.join(timeout=timeout)
+        if polling_thread.is_alive():
+            logger.warning("ShutdownPolling thread did not exit cleanly")
+        else:
+            logger.debug("ShutdownPolling thread stopped cleanly")

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -811,7 +811,7 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
             else:
                 loop.run_until_complete(self.pc.close())
 
-        # 💡 Explicitly stop shutdown observer here
-        if self._session_shutdown_observer:
-            self._session_shutdown_observer.stop()
-            self._session_shutdown_observer = None
+        session_shutdown_observer = self._session_shutdown_observer
+        self._session_shutdown_observer = None
+        if session_shutdown_observer:
+            session_shutdown_observer.stop()

--- a/tests/shutdown_test.py
+++ b/tests/shutdown_test.py
@@ -1,5 +1,6 @@
 import threading
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 from streamlit_webrtc._compat import AppSessionState
@@ -164,3 +165,52 @@ def test_stop_idempotent_and_safe_to_call_after_callback():
         observer.stop()
         # Idempotent.
         observer.stop()
+
+
+class _RaceThread:
+    def __init__(self) -> None:
+        self.first_join_entered = threading.Event()
+        self.release_first_join = threading.Event()
+        self._join_count = 0
+        self._lock = threading.Lock()
+
+    def join(self, timeout=None) -> None:
+        with self._lock:
+            self._join_count += 1
+            join_count = self._join_count
+
+        if join_count == 1:
+            self.first_join_entered.set()
+            self.release_first_join.wait(timeout=3.0)
+        else:
+            self.release_first_join.set()
+
+    def is_alive(self) -> bool:
+        return False
+
+
+def test_stop_safe_when_called_concurrently():
+    errors = []
+    with patch("streamlit_webrtc.shutdown.get_this_session_info", return_value=None):
+        observer = SessionShutdownObserver(lambda: None)
+
+    race_thread = _RaceThread()
+    observer._polling_thread = cast(threading.Thread, race_thread)
+
+    def call_stop():
+        try:
+            observer.stop()
+        except Exception as e:
+            errors.append(e)
+
+    stop_thread = threading.Thread(target=call_stop)
+    stop_thread.start()
+
+    assert race_thread.first_join_entered.wait(timeout=3.0)
+    observer.stop()
+    race_thread.release_first_join.set()
+
+    stop_thread.join(timeout=3.0)
+
+    assert not stop_thread.is_alive()
+    assert errors == []


### PR DESCRIPTION
## Summary

Fixes a race in `SessionShutdownObserver.stop()` that could raise `AttributeError: 'NoneType' object has no attribute 'is_alive'` when overlapping shutdown paths stop the same WebRTC worker.

## Details

The observer now detaches its polling thread under a lock and uses that local thread reference for `join()` and `is_alive()`, making concurrent `stop()` calls idempotent. `WebRtcWorker.stop()` also detaches the observer before stopping it so duplicate cleanup paths converge cleanly.

## Validation

- `uv run pytest tests/shutdown_test.py`
- `uv run ruff format --check streamlit_webrtc/shutdown.py streamlit_webrtc/webrtc.py tests/shutdown_test.py`
- `uv run ruff check streamlit_webrtc/shutdown.py streamlit_webrtc/webrtc.py tests/shutdown_test.py`
- `uv run mypy streamlit_webrtc/shutdown.py streamlit_webrtc/webrtc.py`
- pre-commit hooks on commit: Ruff, Ruff format, mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause crashes during WebRTC worker shutdown when overlapping shutdown procedures execute concurrently, improving application stability during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->