### PR TITLE
[codex] stop workers on frontend disconnect

### DIFF
--- a/changelog.d/20260618_215129_whitphx_frontend-disconnect-termination.md
+++ b/changelog.d/20260618_215129_whitphx_frontend-disconnect-termination.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Stopped WebRTC workers immediately when the frontend detects that its browser-side connection or received track has ended.

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -127,6 +127,7 @@ class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
     _sdp_answer_json: Optional[str]
     _is_sdp_answer_sent: bool
     _last_rendered_run_count: Optional[int]
+    _last_frontend_event_id: Optional[str]
 
     # Passthrough attributes forwarded to the worker. Each returns the
     # worker's attribute when a worker is attached, otherwise None.
@@ -153,6 +154,7 @@ class WebRtcStreamerContext(Generic[VideoProcessorT, AudioProcessorT]):
         self._sdp_answer_json = None
         self._is_sdp_answer_sent = False
         self._last_rendered_run_count = None
+        self._last_frontend_event_id = None
 
     def _set_worker(
         self, worker: Optional[WebRtcWorker[VideoProcessorT, AudioProcessorT]]
@@ -336,6 +338,40 @@ def _reset_orphaned_context(context: WebRtcStreamerContext) -> None:
     context._sdp_answer_json = None
     context._is_sdp_answer_sent = False
     context._component_value_snapshot = None
+    context._last_frontend_event_id = None
+
+
+def _handle_frontend_event(
+    context: WebRtcStreamerContext,
+    key: str,
+    component_value: Union[Dict, None],
+) -> None:
+    if not component_value:
+        return
+
+    frontend_event = component_value.get("frontendEvent")
+    if not isinstance(frontend_event, dict):
+        return
+
+    event_id = frontend_event.get("id")
+    if not event_id or event_id == context._last_frontend_event_id:
+        return
+
+    context._last_frontend_event_id = event_id
+    LOGGER.info(
+        "Frontend requested WebRTC termination (key=%s, type=%s, reason=%s)",
+        key,
+        frontend_event.get("type"),
+        frontend_event.get("reason"),
+    )
+
+    worker = context._get_worker()
+    if worker:
+        worker.stop()
+        context._set_worker(None)
+
+    context._sdp_answer_json = None
+    context._is_sdp_answer_sent = False
 
 
 def _make_state_change_callback(
@@ -352,9 +388,11 @@ def _make_state_change_callback(
 
     def callback() -> None:
         component_value = st.session_state[frontend_key]
-        new_state = compile_state(component_value)
 
         context = st.session_state[key]
+        _handle_frontend_event(context, key, component_value)
+
+        new_state = compile_state(component_value)
         old_state = context.state
         context._set_state(new_state)
 

--- a/streamlit_webrtc/frontend/src/component-value.ts
+++ b/streamlit_webrtc/frontend/src/component-value.ts
@@ -1,9 +1,17 @@
 import { Streamlit } from "streamlit-component-lib";
 
+export interface FrontendEvent {
+  id: string;
+  type: "connection_lost" | "track_ended";
+  reason: string;
+  at: number;
+}
+
 export interface ComponentValue {
   playing: boolean;
   sdpOffer: RTCSessionDescriptionInit | ""; // `Streamlit.setComponentValue` cannot "unset" the field by passing null or undefined, so an empty string will be used here for that purpose. // TODO: Create an issue
   iceCandidates: Record<string, RTCIceCandidateInit>;
+  frontendEvent?: FrontendEvent;
 }
 
 export function setComponentValue(componentValue: ComponentValue) {

--- a/streamlit_webrtc/frontend/src/webrtc/actions.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/actions.ts
@@ -1,3 +1,5 @@
+import { FrontendEvent } from "../component-value";
+
 interface ActionBase {
   type: string;
 }
@@ -19,6 +21,7 @@ interface AddIceCandidateAction extends ActionBase {
 }
 interface StoppingAction extends ActionBase {
   type: "STOPPING";
+  frontendEvent?: FrontendEvent;
 }
 interface StoppedAction extends ActionBase {
   type: "STOPPED";

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -1,6 +1,6 @@
 import { useReducer, useCallback, useRef, useEffect, useMemo } from "react";
 import { compileMediaConstraints } from "../media-constraint";
-import { ComponentValue } from "../component-value";
+import { ComponentValue, FrontendEvent } from "../component-value";
 import { connectReducer, initialState } from "./reducer";
 import { useUniqueId } from "./use-unique-id";
 
@@ -11,6 +11,8 @@ export const isReceivable = (mode: WebRtcMode): boolean =>
   mode === "SENDRECV" || mode === "RECVONLY";
 export const isTransmittable = (mode: WebRtcMode): boolean =>
   mode === "SENDRECV" || mode === "SENDONLY";
+
+type FrontendTerminationEventInput = Pick<FrontendEvent, "type" | "reason">;
 
 export const useWebRtc = (
   props: {
@@ -40,6 +42,8 @@ export const useWebRtc = (
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const pcRef = useRef<RTCPeerConnection>();
+  const frontendEventSequenceRef = useRef(0);
+  const frontendTerminationNotifiedRef = useRef(false);
   const reducer = useMemo(
     () => connectReducer(onComponentValueChange),
     [onComponentValueChange],
@@ -48,50 +52,69 @@ export const useWebRtc = (
 
   const uniqueIdGenerator = useUniqueId();
 
-  const stop = useCallback(() => {
-    const stopInner = async () => {
-      if (state.webRtcState === "STOPPING") {
-        return;
-      }
+  const stop = useCallback(
+    (frontendEventInput?: FrontendTerminationEventInput) => {
+      const stopInner = async () => {
+        if (state.webRtcState === "STOPPING") {
+          return;
+        }
 
-      const pc = pcRef.current;
-      pcRef.current = undefined;
+        const pc = pcRef.current;
+        pcRef.current = undefined;
 
-      dispatch({ type: "STOPPING" });
+        let frontendEvent: FrontendEvent | undefined;
+        const shouldSendFrontendEvent =
+          frontendEventInput && !frontendTerminationNotifiedRef.current;
+        frontendTerminationNotifiedRef.current = true;
+        if (shouldSendFrontendEvent) {
+          frontendEventSequenceRef.current += 1;
+          const at = Date.now();
+          frontendEvent = {
+            ...frontendEventInput,
+            id:
+              globalThis.crypto?.randomUUID?.() ??
+              `${at}-${frontendEventSequenceRef.current}`,
+            at,
+          };
+        }
 
-      if (pc == null) {
-        return;
-      }
+        dispatch({ type: "STOPPING", frontendEvent });
 
-      // close transceivers
-      if (pc.getTransceivers) {
-        pc.getTransceivers().forEach(function (transceiver) {
-          if (transceiver.stop) {
-            transceiver.stop();
-          }
+        if (pc == null) {
+          return;
+        }
+
+        // close transceivers
+        if (pc.getTransceivers) {
+          pc.getTransceivers().forEach(function (transceiver) {
+            if (transceiver.stop) {
+              transceiver.stop();
+            }
+          });
+        }
+
+        // close local audio / video
+        pc.getSenders().forEach(function (sender) {
+          sender.track?.stop();
         });
-      }
 
-      // close local audio / video
-      pc.getSenders().forEach(function (sender) {
-        sender.track?.stop();
-      });
+        // close peer connection
+        return new Promise<void>((resolve) => {
+          setTimeout(() => {
+            pc.close();
+            resolve();
+          }, 500);
+        });
+      };
 
-      // close peer connection
-      return new Promise<void>((resolve) => {
-        setTimeout(() => {
-          pc.close();
-          resolve();
-        }, 500);
-      });
-    };
-
-    stopInner()
-      .catch((error) => dispatch({ type: "ERROR", error }))
-      .finally(() => {
-        dispatch({ type: "STOPPED" });
-      });
-  }, [state.webRtcState]);
+      stopInner()
+        .catch((error) => dispatch({ type: "ERROR", error }))
+        .finally(() => {
+          dispatch({ type: "STOPPED" });
+        });
+    },
+    [state.webRtcState],
+  );
 
   const stopRef = useRef(stop);
   stopRef.current = stop;
@@ -110,6 +133,7 @@ export const useWebRtc = (
       dispatch({ type: "SIGNALLING_START" });
 
       uniqueIdGenerator.reset();
+      frontendTerminationNotifiedRef.current = false;
 
       const mode = props.mode;
 
@@ -121,6 +145,12 @@ export const useWebRtc = (
       if (mode === "SENDRECV" || mode === "RECVONLY") {
         pc.addEventListener("track", (evt) => {
           const stream = evt.streams[0]; // TODO: Handle multiple streams
+          evt.track.addEventListener("ended", () => {
+            stopRef.current({
+              type: "track_ended",
+              reason: `${evt.track.kind} track ended`,
+            });
+          });
           dispatch({ type: "SET_STREAM", stream });
         });
       }
@@ -211,7 +241,24 @@ export const useWebRtc = (
           pc.connectionState === "closed" ||
           pc.connectionState === "failed"
         ) {
-          stopRef.current();
+          stopRef.current({
+            type: "connection_lost",
+            reason: `pc.connectionState=${pc.connectionState}`,
+          });
+        }
+      });
+
+      pc.addEventListener("iceconnectionstatechange", () => {
+        console.debug("iceconnectionstatechange", pc.iceConnectionState);
+        if (
+          pc.iceConnectionState === "disconnected" ||
+          pc.iceConnectionState === "closed" ||
+          pc.iceConnectionState === "failed"
+        ) {
+          stopRef.current({
+            type: "connection_lost",
+            reason: `pc.iceConnectionState=${pc.iceConnectionState}`,
+          });
         }
       });
 

--- a/streamlit_webrtc/frontend/src/webrtc/reducer.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/reducer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+import { connectReducer, initialState } from "./reducer";
+
+describe("connectReducer", () => {
+  it("serializes frontend termination events with a stopped playing state", () => {
+    const onComponentValueChange = vi.fn();
+    const reducer = connectReducer(onComponentValueChange);
+    const frontendEvent = {
+      id: "event-1",
+      type: "connection_lost" as const,
+      reason: "pc.connectionState=failed",
+      at: 123,
+    };
+
+    reducer(
+      { ...initialState, webRtcState: "PLAYING" },
+      { type: "STOPPING", frontendEvent },
+    );
+
+    expect(onComponentValueChange).toHaveBeenCalledWith({
+      playing: false,
+      sdpOffer: "",
+      iceCandidates: {},
+      frontendEvent,
+    });
+  });
+});

--- a/streamlit_webrtc/frontend/src/webrtc/reducer.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/reducer.ts
@@ -6,6 +6,7 @@ export interface State {
   webRtcState: WebRtcState;
   sdpOffer: RTCSessionDescription | null;
   iceCandidates: Record<string, RTCIceCandidate>; // key: candidate id for the server to identify the added candidates
+  frontendEvent: ComponentValue["frontendEvent"] | null;
   stream: MediaStream | null;
   error: Error | null;
 }
@@ -13,6 +14,7 @@ export const initialState: State = {
   webRtcState: "STOPPED",
   sdpOffer: null,
   iceCandidates: {},
+  frontendEvent: null,
   stream: null,
   error: null,
 };
@@ -23,6 +25,7 @@ export const reducer: React.Reducer<State, Action> = (state, action) => {
       return {
         ...state,
         webRtcState: "SIGNALLING",
+        frontendEvent: null,
         stream: null,
         error: null,
       };
@@ -51,6 +54,7 @@ export const reducer: React.Reducer<State, Action> = (state, action) => {
         webRtcState: "STOPPING",
         sdpOffer: null,
         iceCandidates: {},
+        frontendEvent: action.frontendEvent ?? state.frontendEvent,
       };
     case "STOPPED":
       return {
@@ -114,7 +118,15 @@ export const connectReducer = (
       Object.keys(nextIceCandidates).length !==
       Object.keys(prevIceCandidates).length;
 
-    if (playingChanged || sdpOfferChanged || iceCandidatesChanged) {
+    const frontendEventChanged =
+      nextState.frontendEvent !== state.frontendEvent;
+
+    if (
+      playingChanged ||
+      sdpOfferChanged ||
+      iceCandidatesChanged ||
+      frontendEventChanged
+    ) {
       const serializedIceCandidates = Object.fromEntries(
         Object.entries(nextIceCandidates).map(([key, value]) => [
           key,
@@ -122,11 +134,14 @@ export const connectReducer = (
         ]),
       );
 
-      const componentValue = {
+      const componentValue: ComponentValue = {
         playing: nextPlaying,
         sdpOffer: nextSdpOffer ? nextSdpOffer.toJSON() : "", // `Streamlit.setComponentValue` cannot "unset" the field by passing null or undefined, so here an empty string is set instead when `sdpOffer` is undefined. // TODO: Create an issue
         iceCandidates: serializedIceCandidates,
-      } satisfies ComponentValue;
+      };
+      if (nextState.frontendEvent) {
+        componentValue.frontendEvent = nextState.frontendEvent;
+      }
       console.debug("set component value", componentValue);
       onComponentValueChange(componentValue);
     }

--- a/tests/component_pure_test.py
+++ b/tests/component_pure_test.py
@@ -1,6 +1,11 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from streamlit_webrtc.component import (
+    WebRtcStreamerContext,
+    WebRtcStreamerState,
+    _handle_frontend_event,
     _validate_sink_conflicts,
     compile_state,
     generate_frontend_component_key,
@@ -134,3 +139,52 @@ class TestValidateSinkConflicts:
                 on_ended=None,
                 processor_factory=lambda: object(),
             )
+
+
+class TestHandleFrontendEvent:
+    def test_stops_worker_and_clears_pending_answer(self) -> None:
+        worker = MagicMock()
+        context: WebRtcStreamerContext = WebRtcStreamerContext(
+            worker=worker,
+            state=WebRtcStreamerState(playing=True, signalling=False),
+        )
+        context._sdp_answer_json = '{"type":"answer","sdp":"v=0\\r\\n"}'
+        context._is_sdp_answer_sent = True
+
+        _handle_frontend_event(
+            context,
+            "key",
+            {
+                "frontendEvent": {
+                    "id": "event-1",
+                    "type": "connection_lost",
+                    "reason": "pc.connectionState=failed",
+                }
+            },
+        )
+
+        worker.stop.assert_called_once()
+        assert context._get_worker() is None
+        assert context._sdp_answer_json is None
+        assert context._is_sdp_answer_sent is False
+        assert context._last_frontend_event_id == "event-1"
+
+    def test_ignores_duplicate_event(self) -> None:
+        worker = MagicMock()
+        context: WebRtcStreamerContext = WebRtcStreamerContext(
+            worker=worker,
+            state=WebRtcStreamerState(playing=True, signalling=False),
+        )
+        component_value = {
+            "frontendEvent": {
+                "id": "event-1",
+                "type": "connection_lost",
+                "reason": "pc.connectionState=failed",
+            }
+        }
+
+        _handle_frontend_event(context, "key", component_value)
+        context._set_worker(worker)
+        _handle_frontend_event(context, "key", component_value)
+
+        worker.stop.assert_called_once()


### PR DESCRIPTION
## Summary

Stops server-side WebRTC workers immediately when the browser frontend detects that its connection or received track has ended.

## Details

The frontend now includes a `frontendEvent` in the Streamlit component value when browser-side WebRTC reaches a terminal connection state or a received track ends. The backend consumes each event id once, stops the corresponding worker, clears pending SDP answer state, and leaves the existing lifecycle reconciliation as a fallback.

Manual and programmatic stops suppress later cleanup-triggered track-ended events so normal user-initiated stop does not get reported as a frontend connection loss.

## Validation

- `uv run pytest tests/component_pure_test.py tests/get_or_create_context_test.py`
- `pnpm test --run`
- `pnpm lint`
- `pnpm run build`
- pre-commit hooks on commit: Ruff, Ruff format, mypy