### PR TITLE
[codex] Add slow rerun verification app

### DIFF
--- a/changelog.d/20260623_023305_codex_disabled_during_run_sample.md
+++ b/changelog.d/20260623_023305_codex_disabled_during_run_sample.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Add a local verification app for Streamlit's stale UI behavior during slow reruns.

--- a/disabled_during_run.py
+++ b/disabled_during_run.py
@@ -1,0 +1,43 @@
+"""A sample to verify custom component interactivity during a slow rerun."""
+
+import time
+from datetime import datetime
+
+import streamlit as st
+
+from streamlit_webrtc import WebRtcMode, webrtc_streamer
+
+st.title("Disabled during slow rerun")
+
+delay_seconds = st.slider("Slow action duration", min_value=1, max_value=15, value=8)
+
+st.write(
+    "Click the slow action button, then try clicking the WebRTC Start button while "
+    "Streamlit dims the previous UI."
+)
+
+if "slow_action_count" not in st.session_state:
+    st.session_state.slow_action_count = 0
+
+if "native_click_count" not in st.session_state:
+    st.session_state.native_click_count = 0
+
+if st.button("Trigger slow rerun"):
+    st.session_state.slow_action_count += 1
+    started_at = datetime.now().strftime("%H:%M:%S")
+    with st.spinner(f"Sleeping for {delay_seconds} seconds. Started at {started_at}."):
+        time.sleep(delay_seconds)
+
+st.write(f"Slow reruns triggered: {st.session_state.slow_action_count}")
+st.write(f"Last completed render: {datetime.now().strftime('%H:%M:%S')}")
+
+webrtc_streamer(
+    key="disabled-during-run",
+    mode=WebRtcMode.SENDRECV,
+    media_stream_constraints={"video": True, "audio": False},
+)
+
+if st.button("Native control button"):
+    st.session_state.native_click_count += 1
+
+st.write(f"Native control clicks: {st.session_state.native_click_count}")


### PR DESCRIPTION
## Summary

- Adds a root-level `disabled_during_run.py` Streamlit app for manually verifying how Streamlit's stale/dimmed UI behaves during a slow rerun.
- Adds the required changelog fragment under `Chore`.

## Context

This is a local verification app, not a publishable demo page. It keeps the app out of `pages/` so it does not appear in the public demo navigation.

## Validation

- `.venv/bin/python -m py_compile disabled_during_run.py`
- pre-commit hooks during commit: `ruff`, `ruff-format`, `mypy`