### PR TITLE
Wait for peer connection close on worker stop

### DIFF
--- a/changelog.d/20260630_wait_for_peer_close_on_stop.md
+++ b/changelog.d/20260630_wait_for_peer_close_on_stop.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Wait for the peer connection close coroutine when stopping a `WebRtcWorker`,
+  so subsequent starts with the same key do not race against asynchronous peer
+  connection teardown.

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -6,7 +6,6 @@ import logging
 import queue
 import threading
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Dict,
     Generic,

--- a/streamlit_webrtc/webrtc.py
+++ b/streamlit_webrtc/webrtc.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import enum
 import itertools
 import logging
@@ -56,9 +57,6 @@ from .process import (
 from .receive import AudioReceiver, VideoReceiver
 from .relay import get_global_relay
 from .sink import MediaSink
-
-if TYPE_CHECKING:
-    import concurrent.futures
 
 __all__ = [
     "AudioProcessorBase",
@@ -832,7 +830,14 @@ class WebRtcWorker(Generic[VideoProcessorT, AudioProcessorT]):
         if self.pc and self.pc.connectionState != "closed":
             loop = self._loop
             if loop.is_running():
-                asyncio.run_coroutine_threadsafe(self.pc.close(), loop=loop)
+                close_future = asyncio.run_coroutine_threadsafe(
+                    self.pc.close(),
+                    loop=loop,
+                )
+                try:
+                    close_future.result(timeout=timeout)
+                except concurrent.futures.TimeoutError:
+                    logger.warning("Timed out while closing the peer connection")
             else:
                 loop.run_until_complete(self.pc.close())
 

--- a/tests/webrtc_loopback_test.py
+++ b/tests/webrtc_loopback_test.py
@@ -70,9 +70,15 @@ def test_worker_stop_waits_for_peer_connection_close(monkeypatch) -> None:
     worker._relayed_source_video_track = None
     worker.source_video_track = None
 
-    close_future: concurrent.futures.Future = concurrent.futures.Future()
-    close_future.set_result(None)
     closed = {"submitted": False, "waited": False}
+
+    class CloseFuture(concurrent.futures.Future[None]):
+        def result(self, timeout=None) -> None:
+            closed["waited"] = True
+            return super().result(timeout=timeout)
+
+    close_future = CloseFuture()
+    close_future.set_result(None)
 
     class FakeLoop:
         def is_running(self) -> bool:
@@ -83,14 +89,6 @@ def test_worker_stop_waits_for_peer_connection_close(monkeypatch) -> None:
 
         async def close(self) -> None:
             pass
-
-    original_result = close_future.result
-
-    def result(timeout=None):
-        closed["waited"] = True
-        return original_result(timeout=timeout)
-
-    close_future.result = result
 
     def run_coroutine_threadsafe(coro, loop):
         coro.close()
@@ -105,7 +103,6 @@ def test_worker_stop_waits_for_peer_connection_close(monkeypatch) -> None:
     worker.stop(timeout=1.0)
 
     assert closed == {"submitted": True, "waited": True}
-    worker.pc = None
 
 
 def _wire_ice(client: RTCPeerConnection, worker: WebRtcWorker) -> None:

--- a/tests/webrtc_loopback_test.py
+++ b/tests/webrtc_loopback_test.py
@@ -10,6 +10,7 @@ failures.
 """
 
 import asyncio
+import concurrent.futures
 import fractions
 from typing import Any, Dict, List, Set
 
@@ -51,6 +52,60 @@ _WORKER_DEFAULTS: Dict[str, Any] = dict(
 def _source_callback(pts: int, time_base: fractions.Fraction) -> av.VideoFrame:
     arr = np.zeros((32, 32, 3), dtype=np.uint8)
     return av.VideoFrame.from_ndarray(arr, format="bgr24")
+
+
+def test_worker_stop_waits_for_peer_connection_close(monkeypatch) -> None:
+    worker = object.__new__(WebRtcWorker)
+    worker._process_offer_thread = None
+    worker._session_shutdown_observer = None
+    worker._video_processor = None
+    worker._audio_processor = None
+    worker._video_receiver = None
+    worker._audio_receiver = None
+    worker.sink_video_track = None
+    worker.sink_audio_track = None
+    worker._player = None
+    worker._relayed_source_audio_track = None
+    worker.source_audio_track = None
+    worker._relayed_source_video_track = None
+    worker.source_video_track = None
+
+    close_future: concurrent.futures.Future = concurrent.futures.Future()
+    close_future.set_result(None)
+    closed = {"submitted": False, "waited": False}
+
+    class FakeLoop:
+        def is_running(self) -> bool:
+            return True
+
+    class FakePeerConnection:
+        connectionState = "connected"
+
+        async def close(self) -> None:
+            pass
+
+    original_result = close_future.result
+
+    def result(timeout=None):
+        closed["waited"] = True
+        return original_result(timeout=timeout)
+
+    close_future.result = result
+
+    def run_coroutine_threadsafe(coro, loop):
+        coro.close()
+        assert isinstance(loop, FakeLoop)
+        closed["submitted"] = True
+        return close_future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", run_coroutine_threadsafe)
+    worker._loop = FakeLoop()  # type: ignore[assignment]
+    worker.pc = FakePeerConnection()  # type: ignore[assignment]
+
+    worker.stop(timeout=1.0)
+
+    assert closed == {"submitted": True, "waited": True}
+    worker.pc = None
 
 
 def _wire_ice(client: RTCPeerConnection, worker: WebRtcWorker) -> None:


### PR DESCRIPTION
  ## Summary
  - Wait for `RTCPeerConnection.close()` to complete when `WebRtcWorker.stop()` runs on an active event loop
  - Log a warning if peer connection close does not finish within the stop timeout
  - Add a regression test covering the `run_coroutine_threadsafe(...).result(timeout=...)` path

  ## Validation
  - `python -m py_compile streamlit_webrtc/webrtc.py tests/webrtc_loopback_test.py`
  - `git diff --check`
  - `uv run pytest tests/webrtc_loopback_test.py::test_worker_stop_waits_for_peer_connection_close -q`
  - `uv run pytest tests/webrtc_loopback_test.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebRTC shutdown behavior to close peer connections more reliably.
  * The peer-connection close operation is now awaited up to the provided timeout; if it doesn’t complete in time, a warning is logged.
* **Tests**
  * Added a unit test to confirm the worker shutdown path schedules the peer-connection close and waits for it to complete within the specified timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->