### PR TITLE
Reset WebRTC context automatically when sessions end

### DIFF
--- a/changelog.d/20260630_automatic_webrtc_context_reset.md
+++ b/changelog.d/20260630_automatic_webrtc_context_reset.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Reset `webrtc_streamer()` backend state when its frontend session ends, so
+  stale worker, signalling, and component snapshot state are not reused on the
+  next start with the same key.

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -304,7 +304,7 @@ def _get_or_create_context(key: str) -> WebRtcStreamerContext:
                 key,
                 current_run_count - context._last_rendered_run_count - 1,
             )
-            _reset_orphaned_context(context)
+            _reset_context(context)
     else:
         context = WebRtcStreamerContext(
             worker=None, state=WebRtcStreamerState(playing=False, signalling=False)
@@ -323,13 +323,12 @@ def _get_or_create_context(key: str) -> WebRtcStreamerContext:
     return context
 
 
-def _reset_orphaned_context(context: WebRtcStreamerContext) -> None:
-    """Tear down any worker / signalling state on a context that survived a
-    page-away-and-back round-trip. The next `_handle_worker_lifecycle` call
-    will then treat the component as freshly mounted."""
+def _reset_context(context: WebRtcStreamerContext) -> None:
+    """Tear down worker / signalling state so the next lifecycle reconciliation
+    treats the component as freshly mounted."""
     worker = context._get_worker()
     if worker:
-        LOGGER.debug("Stopping orphaned worker.")
+        LOGGER.debug("Stopping worker during context reset.")
         worker.stop()
     context._set_worker(None)
     context._set_state(WebRtcStreamerState(playing=False, signalling=False))
@@ -442,11 +441,8 @@ def _handle_worker_lifecycle(
 
         worker_to_stop = context._get_worker()
         if worker_to_stop:
-            LOGGER.debug("Stop the worker (key=%s).", key)
-            worker_to_stop.stop()
-            context._set_worker(None)
-            context._is_sdp_answer_sent = False
-            context._sdp_answer_json = None
+            LOGGER.debug("Reset the stopped WebRTC context (key=%s).", key)
+            _reset_context(context)
             # Rerun to unset the SDP answer from the frontend args
             rerun()
 

--- a/tests/get_or_create_context_test.py
+++ b/tests/get_or_create_context_test.py
@@ -12,9 +12,11 @@ from unittest.mock import MagicMock, patch
 import streamlit as st
 
 from streamlit_webrtc.component import (
+    ComponentValueSnapshot,
     WebRtcStreamerContext,
     WebRtcStreamerState,
     _get_or_create_context,
+    _handle_worker_lifecycle,
 )
 
 
@@ -124,3 +126,36 @@ def test_orphan_reset_handles_already_stopped_worker():
         _get_or_create_context("key4")
 
     worker.stop.assert_called_once()
+
+
+def test_idle_frontend_resets_worker_and_signalling_state():
+    ctx = WebRtcStreamerContext(
+        worker=None,
+        state=WebRtcStreamerState(playing=False, signalling=False),
+    )
+    worker = MagicMock()
+    ctx._set_worker(worker)
+    ctx._sdp_answer_json = "stub-answer"
+    ctx._is_sdp_answer_sent = True
+    ctx._component_value_snapshot = ComponentValueSnapshot(
+        component_value={"playing": True},
+        run_count=1,
+    )
+    make_worker = MagicMock()
+
+    with patch("streamlit_webrtc.component.rerun") as rerun:
+        _handle_worker_lifecycle(
+            ctx,
+            key="key5",
+            sdp_offer=None,
+            make_worker=make_worker,
+        )
+
+    worker.stop.assert_called_once()
+    make_worker.assert_not_called()
+    rerun.assert_called_once()
+    assert ctx._get_worker() is None
+    assert ctx.state == WebRtcStreamerState(playing=False, signalling=False)
+    assert ctx._sdp_answer_json is None
+    assert ctx._is_sdp_answer_sent is False
+    assert ctx._component_value_snapshot is None


### PR DESCRIPTION
  ## Summary

  Reset `webrtc_streamer()` backend context automatically when the frontend session ends and the worker is stopped.

  This reuses the existing stale-context reset path for normal WebRTC session teardown, so a subsequent start with the same component key does not reuse stale worker, signalling, SDP answer, or component snapshot
  state.

  ## Motivation

  Apps should not need to reach into private `WebRtcStreamerContext` fields or rotate component keys just to make STOP/START reliable. After #2530 handles factory-created source/sink track lifecycles, this
  handles the remaining `webrtc_streamer()` context state internally.

  ## Changes

  - Generalizes the orphaned-context reset helper to `_reset_context()`.
  - Calls `_reset_context()` from `_handle_worker_lifecycle()` when the frontend is idle and a worker still exists.
  - Clears worker, state, SDP answer, answer-sent flag, and component snapshot state.
  - Adds a regression test for idle frontend teardown.
  - Adds a changelog fragment.

  ## Validation

  - `uv run ruff format streamlit_webrtc/component.py streamlit_webrtc/__init__.py tests/get_or_create_context_test.py`
  - `uv run ruff check streamlit_webrtc/component.py streamlit_webrtc/__init__.py tests/get_or_create_context_test.py`
  - `uv run pytest tests/get_or_create_context_test.py -q`
  - `uv run mypy .`
  - `uv run mkdocs build --strict`
  - `uv run scriv print`
  - `git diff --check`