### PR TITLE
Fix the forked multi output example to start signalling on secondary …

### DIFF
--- a/pages/5_fork_multi_outputs.py
+++ b/pages/5_fork_multi_outputs.py
@@ -79,7 +79,7 @@ webrtc_streamer(
     mode=WebRtcMode.RECVONLY,
     video_frame_callback=callback,
     source_video_track=ctx.output_video_track,
-    desired_playing_state=ctx.state.playing,
+    desired_playing_state=ctx.state.signalling or ctx.state.playing,
     media_stream_constraints={"video": True, "audio": False},
 )
 
@@ -95,6 +95,6 @@ webrtc_streamer(
     mode=WebRtcMode.RECVONLY,
     video_frame_callback=callback,
     source_video_track=ctx.output_video_track,
-    desired_playing_state=ctx.state.playing,
+    desired_playing_state=ctx.state.signalling or ctx.state.playing,
     media_stream_constraints={"video": True, "audio": False},
 )


### PR DESCRIPTION
…widgets when the primary widgets starts signalling, without waiting for it to be in the playing state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forked WebRTC outputs now start and stay active during the signaling phase, improving playback behavior before the stream fully transitions to playing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->