### PR TITLE
Reset stale SDP answer on stopped sessions

### DIFF
--- a/changelog.d/fix-stale-sdp-answer.md
+++ b/changelog.d/fix-stale-sdp-answer.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Reset stale SDP answer state left in an idle WebRTC context so a stopped
+  session can start again without requiring an extra cancellation.

--- a/streamlit_webrtc/component.py
+++ b/streamlit_webrtc/component.py
@@ -440,7 +440,10 @@ def _handle_worker_lifecycle(
         )
 
         worker_to_stop = context._get_worker()
-        if worker_to_stop:
+        has_stale_sdp_answer = (
+            context._sdp_answer_json is not None or context._is_sdp_answer_sent
+        )
+        if worker_to_stop or has_stale_sdp_answer:
             LOGGER.debug("Reset the stopped WebRTC context (key=%s).", key)
             _reset_context(context)
             # Rerun to unset the SDP answer from the frontend args

--- a/tests/component_pure_test.py
+++ b/tests/component_pure_test.py
@@ -1,6 +1,13 @@
+from typing import Any
+
 import pytest
 
+import streamlit_webrtc.component as component
 from streamlit_webrtc.component import (
+    ComponentValueSnapshot,
+    WebRtcStreamerContext,
+    WebRtcStreamerState,
+    _handle_worker_lifecycle,
     _validate_sink_conflicts,
     compile_state,
     generate_frontend_component_key,
@@ -61,6 +68,50 @@ class TestGenerateFrontendComponentKey:
         assert generate_frontend_component_key(
             "x:frontend"
         ) != generate_frontend_component_key("x")
+
+
+class TestHandleWorkerLifecycle:
+    def test_idle_stale_sdp_answer_resets_context_and_reruns(self, monkeypatch) -> None:
+        reruns: list[bool] = []
+        monkeypatch.setattr(component, "rerun", lambda: reruns.append(True))
+        context: WebRtcStreamerContext[Any, Any] = WebRtcStreamerContext(
+            worker=None, state=WebRtcStreamerState(playing=False, signalling=False)
+        )
+        context._sdp_answer_json = '{"sdp":"v=0\\r\\n","type":"answer"}'
+        context._is_sdp_answer_sent = True
+        context._component_value_snapshot = ComponentValueSnapshot(
+            component_value={"playing": False}, run_count=1
+        )
+
+        _handle_worker_lifecycle(
+            context,
+            key="k",
+            sdp_offer=None,
+            make_worker=lambda: pytest.fail("worker should not be created"),
+        )
+
+        assert context._get_worker() is None
+        assert context.state == WebRtcStreamerState(playing=False, signalling=False)
+        assert context._sdp_answer_json is None
+        assert context._is_sdp_answer_sent is False
+        assert context._component_value_snapshot is None
+        assert reruns == [True]
+
+    def test_idle_without_worker_or_stale_sdp_does_not_rerun(self, monkeypatch) -> None:
+        reruns: list[bool] = []
+        monkeypatch.setattr(component, "rerun", lambda: reruns.append(True))
+        context: WebRtcStreamerContext[Any, Any] = WebRtcStreamerContext(
+            worker=None, state=WebRtcStreamerState(playing=False, signalling=False)
+        )
+
+        _handle_worker_lifecycle(
+            context,
+            key="k",
+            sdp_offer=None,
+            make_worker=lambda: pytest.fail("worker should not be created"),
+        )
+
+        assert reruns == []
 
 
 class TestValidateSinkConflicts:


### PR DESCRIPTION
  ## Summary

  - Reset idle WebRTC contexts that no longer have a worker but still retain SDP answer state.
  - Prevent the next START from reusing a stale SDP answer and getting stuck in signalling after a previous session stops.
  - Add regression coverage for the idle/no-worker/stale-SDP state.

  ## Background

  This fixes a restart issue observed when a session stops cleanly, but the backend context is left in this shape:

  - playing=False
  - signalling=False
  - no active worker
  - stale SDP answer fields still set

  In that state, the next session can fail to establish until the user cancels and retries. The existing lifecycle reset handled idle contexts with a remaining worker, but not idle contexts where only SDP answer state remained.

  ## Tests

  - uv run --frozen pytest tests/component_pure_test.py
  - uv run --frozen ruff format --check streamlit_webrtc/component.py tests/component_pure_test.py
  - uv run --frozen ruff check streamlit_webrtc/component.py tests/component_pure_test.py
  - uv run --frozen mypy .
  - git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a stopped WebRTC session could get stuck with stale answer state, preventing it from starting again cleanly.
  * Idle sessions now reset properly when leftover connection state is detected, so restarting is more reliable.
  * Improved handling to avoid unnecessary restarts when no stale session state exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->