### PR TITLE
[codex] Set explicit GitHub Release title

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -166,11 +166,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
         TAG_NAME: ${{ needs.get-build-info.outputs.tag }}
-      run: >-
-        gh release create
-        "$TAG_NAME"
-        --repo "$GITHUB_REPOSITORY"
-        --notes ""
+      run: |
+        gh release create \
+          "$TAG_NAME" \
+          --repo "$GITHUB_REPOSITORY" \
+          --title "${TAG_NAME#v}" \
+          --notes "" \
+          --verify-tag
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/changelog.d/20260702_134347_chore_release_title.md
+++ b/changelog.d/20260702_134347_chore_release_title.md
@@ -1,0 +1,3 @@
+### Chore
+
+- Set explicit GitHub Release titles from version tags.


### PR DESCRIPTION
## Summary

- Set `gh release create` to use an explicit release title derived from the version tag.
- Add `--verify-tag` so the release job fails if the expected tag is missing.
- Add a Chore changelog fragment for the release automation fix.

## Root Cause

The release workflow created GitHub Releases without a `--title`, leaving the stored release `name` as `null`. GitHub then displayed a fallback title based on the tag and tagged commit title, such as `v0.74.1: Preview changelog for next release (0.74.1) (#2541)`.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/post-build.yml"); puts "ok"'`
- `actionlint -ignore 'SC2086' .github/workflows/post-build.yml`

Note: plain `actionlint` still reports pre-existing `SC2086` warnings in the unrelated `Read build info` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Releases now use a clear title based on the version tag.
  * Release creation now verifies the tag before publishing, adding an extra safeguard.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->