### PR TITLE
[codex] Recommend streamlit-remote for HTTPS development

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,18 @@ If not, you will encounter an error when starting using the device. For example,
 
 [Streamlit Community Cloud](https://streamlit.io/cloud) is a recommended way for HTTPS serving. You can easily deploy Streamlit apps with it, and most importantly for this topic, it serves the apps via HTTPS automatically by default.
 
-For the development purpose, sometimes [`suyashkumar/ssl-proxy`](https://github.com/suyashkumar/ssl-proxy) is a convenient tool to serve your app via HTTPS.
+For development, [`streamlit-remote`](https://github.com/whitphx/streamlit-remote) provides the `st-remote` command as an easy way to serve your app via HTTPS.
+For remote HTTPS access, `st-remote` works as a wrapper that starts Streamlit and then runs a tunnel provider command such as `cloudflared` or `ngrok`.
+Install the provider command separately before running `st-remote`: use `cloudflared` with `--provider cloudflare`, or `ngrok` with `--provider ngrok`.
+`st-remote` defaults to `--provider cloudflare`; it does not automatically choose a provider based on which command is installed.
+The `--provider` option only affects the remote tunnel; if you only need HTTPS on your local machine, use local HTTPS mode instead.
+See [`streamlit-remote`'s README](https://github.com/whitphx/streamlit-remote#readme) for provider installation and option details.
 ```shell
-$ streamlit run your_app.py  # Assume your app is running on http://localhost:8501
-# Then, after downloading the binary from the GitHub page above to ./ssl-proxy,
-$ ./ssl-proxy -from 0.0.0.0:8000 -to 127.0.0.1:8501  # Proxy the HTTP page from port 8501 to port 8000 via HTTPS
-# Then access https://localhost:8000
+$ pip install streamlit-remote
+$ st-remote your_app.py --provider cloudflare  # Remote HTTPS URL via cloudflared.
+$ st-remote your_app.py --provider ngrok  # Remote HTTPS URL via ngrok.
+$ st-remote your_app.py --https self-signed --no-remote  # Local HTTPS only.
+# Then access the HTTPS URL printed by st-remote.
 ```
 
 ### Configure the STUN server

--- a/changelog.d/20260704_014717_t.yic.yt_streamlit_remote_readme.md
+++ b/changelog.d/20260704_014717_t.yic.yt_streamlit_remote_readme.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- Updated the HTTPS development instructions to recommend `streamlit-remote` for remote or local HTTPS serving.
+- Updated the HTTPS development instructions in the README and deployment guide to recommend `streamlit-remote` for remote or local HTTPS serving.

--- a/changelog.d/20260704_014717_t.yic.yt_streamlit_remote_readme.md
+++ b/changelog.d/20260704_014717_t.yic.yt_streamlit_remote_readme.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Updated the HTTPS development instructions to recommend `streamlit-remote` for remote or local HTTPS serving.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,16 +25,19 @@ If not, you will encounter an error when starting to use the device. For example
 
 **[Streamlit Community Cloud](https://streamlit.io/cloud)** is the recommended way for HTTPS serving. You can easily deploy Streamlit apps with it, and most importantly, it serves the apps via HTTPS automatically by default.
 
-**For development purposes**, sometimes [`suyashkumar/ssl-proxy`](https://github.com/suyashkumar/ssl-proxy) is a convenient tool to serve your app via HTTPS:
+**For development**, [`streamlit-remote`](https://github.com/whitphx/streamlit-remote) provides the `st-remote` command as an easy way to serve your app via HTTPS.
+For remote HTTPS access, `st-remote` works as a wrapper that starts Streamlit and then runs a tunnel provider command such as `cloudflared` or `ngrok`.
+Install the provider command separately before running `st-remote`: use `cloudflared` with `--provider cloudflare`, or `ngrok` with `--provider ngrok`.
+`st-remote` defaults to `--provider cloudflare`; it does not automatically choose a provider based on which command is installed.
+The `--provider` option only affects the remote tunnel; if you only need HTTPS on your local machine, use local HTTPS mode instead.
+See [`streamlit-remote`'s README](https://github.com/whitphx/streamlit-remote#readme) for provider installation and option details.
 
 ```bash
-# Assume your app is running on http://localhost:8501
-streamlit run your_app.py
-
-# Then, after downloading the binary from the GitHub page above to ./ssl-proxy
-./ssl-proxy -from 0.0.0.0:8000 -to 127.0.0.1:8501
-
-# Then access https://localhost:8000
+pip install streamlit-remote
+st-remote your_app.py --provider cloudflare  # Remote HTTPS URL via cloudflared.
+st-remote your_app.py --provider ngrok  # Remote HTTPS URL via ngrok.
+st-remote your_app.py --https self-signed --no-remote  # Local HTTPS only.
+# Then access the HTTPS URL printed by st-remote.
 ```
 
 ## STUN Server Configuration
@@ -143,7 +146,7 @@ When deploying to other platforms (AWS, GCP, Azure, etc.):
 
 Before going live, test your deployment:
 
-1. **Local HTTPS testing** - Use ssl-proxy or similar tools
+1. **Local HTTPS testing** - Use `streamlit-remote` local HTTPS mode, or a remote HTTPS tunnel with an explicit provider
 2. **Network testing** - Test from different network environments
 3. **Browser testing** - Test across different browsers and devices
 4. **Performance testing** - Monitor resource usage and frame rates


### PR DESCRIPTION
## Summary

- Replace the old `ssl-proxy` development HTTPS examples in the README and deployment guide with `streamlit-remote` / `st-remote` instructions.
- Explain that remote HTTPS uses a provider command run by `st-remote`, and that `cloudflared` or `ngrok` must be installed separately depending on `--provider`.
- Add local HTTPS-only examples and update the changelog fragment.

## Validation

- Pre-commit ran during both commits; ruff, ruff-format, and mypy had no matching files to check because this is a docs/changelog-only change.
- CI was watched after the first push and passed; checks are being watched again after the deployment guide update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Replaced the previous “development” HTTPS instructions (based on a local HTTPS proxy approach) with a new workflow using `streamlit-remote` for remote HTTPS access and local HTTPS testing.
  - Added command examples for common tunnel providers and a local self-signed HTTPS mode.
  - Clarified `--provider` behavior/defaults and that provider support requires an additional installation step.
  - Updated the deployment testing checklist to recommend the new HTTPS options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->