### PR TITLE
Allow switching input devices while streaming

### DIFF
--- a/changelog.d/20260711_150018_t.yic.yt_live_device_selection.md
+++ b/changelog.d/20260711_150018_t.yic.yt_live_device_selection.md
@@ -1,0 +1,3 @@
+### Added
+
+- Input cameras and microphones can now be changed while streaming.

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.stories.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.stories.tsx
@@ -6,7 +6,9 @@ const Base: Story<DeviceSelectProps> = (props: DeviceSelectProps) => (
   <DeviceSelect {...props} />
 );
 Base.argTypes = {
-  onSelect: { action: "selected" },
+  onSelectionResolved: { action: "selection resolved" },
+  onVideoSelect: { action: "video selected" },
+  onAudioSelect: { action: "audio selected" },
 };
 
 export const Both = Base.bind({});
@@ -15,7 +17,9 @@ Both.args = {
   audio: true,
   defaultVideoDeviceId: undefined,
   defaultAudioDeviceId: undefined,
-  onSelect: () => {},
+  onSelectionResolved: () => {},
+  onVideoSelect: () => {},
+  onAudioSelect: () => {},
 };
 
 export const VideoOnly = Base.bind({});
@@ -24,7 +28,9 @@ VideoOnly.args = {
   audio: false,
   defaultVideoDeviceId: undefined,
   defaultAudioDeviceId: undefined,
-  onSelect: () => {},
+  onSelectionResolved: () => {},
+  onVideoSelect: () => {},
+  onAudioSelect: () => {},
 };
 
 export const AudioOnly = Base.bind({});
@@ -33,5 +39,7 @@ AudioOnly.args = {
   audio: true,
   defaultVideoDeviceId: undefined,
   defaultAudioDeviceId: undefined,
-  onSelect: () => {},
+  onSelectionResolved: () => {},
+  onVideoSelect: () => {},
+  onAudioSelect: () => {},
 };

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
@@ -1,0 +1,99 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DeviceSelect from "./DeviceSelect";
+
+vi.mock("streamlit-component-lib", () => ({
+  Streamlit: { setFrameHeight: vi.fn() },
+}));
+
+vi.mock("./VideoPreview", () => ({
+  default: () => <div />,
+}));
+
+function makeDevice(deviceId: string): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: "video-group",
+    kind: "videoinput",
+    label: deviceId,
+    toJSON: () => ({}),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("<DeviceSelect />", () => {
+  it("rolls back only the latest rejected selection", async () => {
+    let rejectFirstSelection: ((error: Error) => void) | undefined;
+    let rejectSecondSelection: ((error: Error) => void) | undefined;
+    const onVideoSelect = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectFirstSelection = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectSecondSelection = reject;
+          }),
+      );
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue({
+          getTracks: () => [],
+          getVideoTracks: () => [],
+          getAudioTracks: () => [],
+        }),
+        enumerateDevices: vi
+          .fn()
+          .mockResolvedValue([
+            makeDevice("old-video"),
+            makeDevice("first-video"),
+            makeDevice("second-video"),
+          ]),
+        ondevicechange: null,
+      },
+    });
+
+    render(
+      <DeviceSelect
+        video
+        audio={false}
+        defaultVideoDeviceId="old-video"
+        defaultAudioDeviceId={undefined}
+        onSelectionResolved={vi.fn()}
+        onVideoSelect={onVideoSelect}
+        onAudioSelect={vi.fn()}
+      />,
+    );
+
+    const select = (await screen.findByLabelText(
+      "Video Input",
+    )) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "first-video" } });
+    fireEvent.change(select, { target: { value: "second-video" } });
+    expect(select.value).toBe("second-video");
+
+    await act(async () =>
+      rejectFirstSelection?.(new Error("First switch failed")),
+    );
+    expect(select.value).toBe("second-video");
+
+    await act(async () =>
+      rejectSecondSelection?.(new Error("Second switch failed")),
+    );
+    expect(select.value).toBe("old-video");
+  });
+});

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -127,8 +127,12 @@ export interface DeviceSelectProps {
     video?: MediaDeviceInfo["deviceId"];
     audio?: MediaDeviceInfo["deviceId"];
   }) => void;
-  onVideoSelect: (deviceId: MediaDeviceInfo["deviceId"]) => void;
-  onAudioSelect: (deviceId: MediaDeviceInfo["deviceId"]) => void;
+  onVideoSelect: (
+    deviceId: MediaDeviceInfo["deviceId"],
+  ) => Promise<void> | void;
+  onAudioSelect: (
+    deviceId: MediaDeviceInfo["deviceId"],
+  ) => Promise<void> | void;
 }
 function DeviceSelect(props: DeviceSelectProps) {
   const {
@@ -188,6 +192,7 @@ function DeviceSelect(props: DeviceSelectProps) {
     video: defaultVideoDeviceId,
     audio: defaultAudioDeviceId,
   };
+  const selectionRequestIdsRef = useRef({ video: 0, audio: 0 });
   // Call `getUserMedia()` to ask the user for the permission.
   useEffect(() => {
     if (typeof navigator?.mediaDevices?.getUserMedia !== "function") {
@@ -239,11 +244,24 @@ function DeviceSelect(props: DeviceSelectProps) {
   >(
     (e) => {
       const video = e.target.value;
+      const requestId = ++selectionRequestIdsRef.current.video;
       deviceSelectionDispatch({
         type: "UPDATE_SELECTED_DEVICE_ID",
         payload: { selectedVideoInputDeviceId: video },
       });
-      onVideoSelect(video);
+      void Promise.resolve()
+        .then(() => onVideoSelect(video))
+        .catch(() => {
+          if (selectionRequestIdsRef.current.video !== requestId) {
+            return;
+          }
+          deviceSelectionDispatch({
+            type: "UPDATE_SELECTED_DEVICE_ID",
+            payload: {
+              selectedVideoInputDeviceId: defaultDeviceIdsRef.current.video,
+            },
+          });
+        });
     },
     [onVideoSelect],
   );
@@ -253,11 +271,24 @@ function DeviceSelect(props: DeviceSelectProps) {
   >(
     (e) => {
       const audio = e.target.value;
+      const requestId = ++selectionRequestIdsRef.current.audio;
       deviceSelectionDispatch({
         type: "UPDATE_SELECTED_DEVICE_ID",
         payload: { selectedAudioInputDeviceId: audio },
       });
-      onAudioSelect(audio);
+      void Promise.resolve()
+        .then(() => onAudioSelect(audio))
+        .catch(() => {
+          if (selectionRequestIdsRef.current.audio !== requestId) {
+            return;
+          }
+          deviceSelectionDispatch({
+            type: "UPDATE_SELECTED_DEVICE_ID",
+            payload: {
+              selectedAudioInputDeviceId: defaultDeviceIdsRef.current.audio,
+            },
+          });
+        });
     },
     [onAudioSelect],
   );

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -123,13 +123,12 @@ export interface DeviceSelectProps {
   audio: boolean;
   defaultVideoDeviceId: MediaDeviceInfo["deviceId"] | undefined;
   defaultAudioDeviceId: MediaDeviceInfo["deviceId"] | undefined;
-  onSelect: (
-    devices: {
-      video?: MediaDeviceInfo["deviceId"];
-      audio?: MediaDeviceInfo["deviceId"];
-    },
-    changedKind?: "video" | "audio",
-  ) => void;
+  onSelectionResolved: (devices: {
+    video?: MediaDeviceInfo["deviceId"];
+    audio?: MediaDeviceInfo["deviceId"];
+  }) => void;
+  onVideoSelect: (deviceId: MediaDeviceInfo["deviceId"]) => void;
+  onAudioSelect: (deviceId: MediaDeviceInfo["deviceId"]) => void;
 }
 function DeviceSelect(props: DeviceSelectProps) {
   const {
@@ -137,7 +136,9 @@ function DeviceSelect(props: DeviceSelectProps) {
     audio: useAudio,
     defaultVideoDeviceId,
     defaultAudioDeviceId,
-    onSelect,
+    onSelectionResolved,
+    onVideoSelect,
+    onAudioSelect,
   } = props;
 
   const [permissionState, setPermissionState] =
@@ -242,9 +243,9 @@ function DeviceSelect(props: DeviceSelectProps) {
         type: "UPDATE_SELECTED_DEVICE_ID",
         payload: { selectedVideoInputDeviceId: video },
       });
-      onSelect({ video, audio: selectedAudioInputDeviceId }, "video");
+      onVideoSelect(video);
     },
-    [onSelect, selectedAudioInputDeviceId],
+    [onVideoSelect],
   );
 
   const handleAudioInputChange = useCallback<
@@ -256,12 +257,11 @@ function DeviceSelect(props: DeviceSelectProps) {
         type: "UPDATE_SELECTED_DEVICE_ID",
         payload: { selectedAudioInputDeviceId: audio },
       });
-      onSelect({ video: selectedVideoInputDeviceId, audio }, "audio");
+      onAudioSelect(audio);
     },
-    [onSelect, selectedVideoInputDeviceId],
+    [onAudioSelect],
   );
 
-  // Call onSelect
   useEffect(() => {
     const videoInput = useVideo
       ? videoInputs.find((d) => d.deviceId === selectedVideoInputDeviceId)
@@ -269,11 +269,14 @@ function DeviceSelect(props: DeviceSelectProps) {
     const audioInput = useAudio
       ? audioInputs.find((d) => d.deviceId === selectedAudioInputDeviceId)
       : null;
-    onSelect({ video: videoInput?.deviceId, audio: audioInput?.deviceId });
+    onSelectionResolved({
+      video: videoInput?.deviceId,
+      audio: audioInput?.deviceId,
+    });
   }, [
     useVideo,
     useAudio,
-    onSelect,
+    onSelectionResolved,
     videoInputs,
     audioInputs,
     selectedVideoInputDeviceId,

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -123,10 +123,13 @@ export interface DeviceSelectProps {
   audio: boolean;
   defaultVideoDeviceId: MediaDeviceInfo["deviceId"] | undefined;
   defaultAudioDeviceId: MediaDeviceInfo["deviceId"] | undefined;
-  onSelect: (devices: {
-    video: MediaDeviceInfo["deviceId"] | undefined;
-    audio: MediaDeviceInfo["deviceId"] | undefined;
-  }) => void;
+  onSelect: (
+    devices: {
+      video?: MediaDeviceInfo["deviceId"];
+      audio?: MediaDeviceInfo["deviceId"];
+    },
+    changedKind?: "video" | "audio",
+  ) => void;
 }
 function DeviceSelect(props: DeviceSelectProps) {
   const {
@@ -232,25 +235,31 @@ function DeviceSelect(props: DeviceSelectProps) {
 
   const handleVideoInputChange = useCallback<
     NonNullable<NativeSelectProps["onChange"]>
-  >((e) => {
-    deviceSelectionDispatch({
-      type: "UPDATE_SELECTED_DEVICE_ID",
-      payload: {
-        selectedVideoInputDeviceId: e.target.value,
-      },
-    });
-  }, []);
+  >(
+    (e) => {
+      const video = e.target.value;
+      deviceSelectionDispatch({
+        type: "UPDATE_SELECTED_DEVICE_ID",
+        payload: { selectedVideoInputDeviceId: video },
+      });
+      onSelect({ video, audio: selectedAudioInputDeviceId }, "video");
+    },
+    [onSelect, selectedAudioInputDeviceId],
+  );
 
   const handleAudioInputChange = useCallback<
     NonNullable<NativeSelectProps["onChange"]>
-  >((e) => {
-    deviceSelectionDispatch({
-      type: "UPDATE_SELECTED_DEVICE_ID",
-      payload: {
-        selectedAudioInputDeviceId: e.target.value,
-      },
-    });
-  }, []);
+  >(
+    (e) => {
+      const audio = e.target.value;
+      deviceSelectionDispatch({
+        type: "UPDATE_SELECTED_DEVICE_ID",
+        payload: { selectedAudioInputDeviceId: audio },
+      });
+      onSelect({ video: selectedVideoInputDeviceId, audio }, "audio");
+    },
+    [onSelect, selectedVideoInputDeviceId],
+  );
 
   // Call onSelect
   useEffect(() => {

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelectForm.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelectForm.tsx
@@ -1,18 +1,26 @@
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import Alert from "@mui/material/Alert";
 import DeviceSelect, { DeviceSelectProps } from "./DeviceSelect";
 
 export interface DeviceSelectFormProps extends DeviceSelectProps {
   onClose: () => void;
+  switchError?: Error | null;
 }
 function DeviceSelectForm({
   onClose,
+  switchError,
   ...deviceSelectProps
 }: DeviceSelectFormProps) {
   return (
     <Stack spacing={2}>
       <DeviceSelect {...deviceSelectProps} />
+      {switchError != null && (
+        <Alert severity="error">
+          {switchError.name}: {switchError.message}
+        </Alert>
+      )}
       <Box>
         <Button variant="contained" color="primary" onClick={onClose}>
           Done

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { useEffect } from "react";
 import { WebRtcStreamerInner } from "./WebRtcStreamer";
@@ -34,17 +35,28 @@ vi.mock("./device-storage", () => ({
 vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
   default: function MockDeviceSelectForm(props: {
     onSelectionResolved: (devices: { video?: string; audio?: string }) => void;
-    onVideoSelect: (deviceId: string) => void;
+    onVideoSelect: (deviceId: string) => Promise<void> | void;
+    onAudioSelect: (deviceId: string) => Promise<void> | void;
     switchError?: Error | null;
   }) {
-    const { onSelectionResolved, onVideoSelect, switchError } = props;
+    const { onSelectionResolved, onVideoSelect, onAudioSelect, switchError } =
+      props;
     useEffect(() => {
       onSelectionResolved({ video: "old-video", audio: "old-audio" });
     }, [onSelectionResolved]);
+    const selectVideo = () => {
+      void Promise.resolve(onVideoSelect("new-video")).catch(() => undefined);
+    };
+    const selectAudio = () => {
+      void Promise.resolve(onAudioSelect("new-audio")).catch(() => undefined);
+    };
     return (
       <div>
-        <button type="button" onClick={() => onVideoSelect("new-video")}>
+        <button type="button" onClick={selectVideo}>
           Choose another camera
+        </button>
+        <button type="button" onClick={selectAudio}>
+          Choose another microphone
         </button>
         {switchError != null && <div role="alert">{switchError.message}</div>}
       </div>
@@ -193,5 +205,43 @@ describe("<WebRtcStreamerInner />", () => {
       "Device is busy",
     );
     expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
+  it("preserves both confirmed IDs when video and audio switches overlap", async () => {
+    let finishVideoSwitch: (() => void) | undefined;
+    let finishAudioSwitch: (() => void) | undefined;
+    const updateInputDevice = vi.fn((kind: "video" | "audio") => {
+      return new Promise<void>((resolve) => {
+        if (kind === "video") {
+          finishVideoSwitch = resolve;
+        } else {
+          finishAudioSwitch = resolve;
+        }
+      });
+    });
+    renderStreamer({ updateInputDevice });
+    fireEvent.click(screen.getByRole("button", { name: "Select Device" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Choose another camera" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Choose another microphone" }),
+    );
+
+    await act(async () => finishAudioSwitch?.());
+    await waitFor(() =>
+      expect(persistDeviceIds).toHaveBeenLastCalledWith("test-key", {
+        video: "old-video",
+        audio: "new-audio",
+      }),
+    );
+
+    await act(async () => finishVideoSwitch?.());
+    await waitFor(() =>
+      expect(persistDeviceIds).toHaveBeenLastCalledWith("test-key", {
+        video: "new-video",
+        audio: "new-audio",
+      }),
+    );
   });
 });

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -33,24 +33,17 @@ vi.mock("./device-storage", () => ({
 
 vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
   default: function MockDeviceSelectForm(props: {
-    onSelect: (
-      devices: { video?: string; audio?: string },
-      changedKind?: "video" | "audio",
-    ) => void;
+    onSelectionResolved: (devices: { video?: string; audio?: string }) => void;
+    onVideoSelect: (deviceId: string) => void;
     switchError?: Error | null;
   }) {
-    const { onSelect, switchError } = props;
+    const { onSelectionResolved, onVideoSelect, switchError } = props;
     useEffect(() => {
-      onSelect({ video: "old-video", audio: "old-audio" });
-    }, [onSelect]);
+      onSelectionResolved({ video: "old-video", audio: "old-audio" });
+    }, [onSelectionResolved]);
     return (
       <div>
-        <button
-          type="button"
-          onClick={() =>
-            onSelect({ video: "new-video", audio: "old-audio" }, "video")
-          }
-        >
+        <button type="button" onClick={() => onVideoSelect("new-video")}>
           Choose another camera
         </button>
         {switchError != null && <div role="alert">{switchError.message}</div>}

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -45,6 +45,7 @@ function renderStreamer({
     },
     start: vi.fn(),
     stop: vi.fn(),
+    updateInputDevices: vi.fn(),
   });
 
   render(
@@ -87,5 +88,13 @@ describe("<WebRtcStreamerInner />", () => {
     expect(
       screen.queryByRole("button", { name: "Mute microphone" }),
     ).toBeNull();
+  });
+
+  it("shows the device selector while streaming", () => {
+    renderStreamer();
+
+    expect(
+      screen.getByRole("button", { name: "Select Device" }),
+    ).not.toBeNull();
   });
 });

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -1,7 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useEffect } from "react";
 import { WebRtcStreamerInner } from "./WebRtcStreamer";
 import { useWebRtc } from "./webrtc";
+import { persistDeviceIds } from "./device-storage";
 
 vi.mock("streamlit-component-lib-react-hooks", () => ({
   useRenderData: vi.fn(),
@@ -14,6 +22,42 @@ vi.mock("./webrtc", async (importOriginal) => {
     useWebRtc: vi.fn(),
   };
 });
+
+vi.mock("./device-storage", () => ({
+  loadPersistedDeviceIds: () => ({
+    video: "old-video",
+    audio: "old-audio",
+  }),
+  persistDeviceIds: vi.fn(),
+}));
+
+vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
+  default: function MockDeviceSelectForm(props: {
+    onSelect: (
+      devices: { video?: string; audio?: string },
+      changedKind?: "video" | "audio",
+    ) => void;
+    switchError?: Error | null;
+  }) {
+    const { onSelect, switchError } = props;
+    useEffect(() => {
+      onSelect({ video: "old-video", audio: "old-audio" });
+    }, [onSelect]);
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            onSelect({ video: "new-video", audio: "old-audio" }, "video")
+          }
+        >
+          Choose another camera
+        </button>
+        {switchError != null && <div role="alert">{switchError.message}</div>}
+      </div>
+    );
+  },
+}));
 
 afterEach(() => {
   cleanup();
@@ -31,8 +75,15 @@ function makeStream() {
 
 function renderStreamer({
   mediaToggleControls = true,
+  updateInputDevice = vi
+    .fn<(kind: "video" | "audio", deviceId: string) => Promise<void>>()
+    .mockResolvedValue(undefined),
 }: {
   mediaToggleControls?: boolean;
+  updateInputDevice?: (
+    kind: "video" | "audio",
+    deviceId: string,
+  ) => Promise<void>;
 } = {}) {
   vi.mocked(useWebRtc).mockReturnValue({
     state: {
@@ -45,7 +96,7 @@ function renderStreamer({
     },
     start: vi.fn(),
     stop: vi.fn(),
-    updateInputDevices: vi.fn(),
+    updateInputDevice,
   });
 
   render(
@@ -65,6 +116,8 @@ function renderStreamer({
       onComponentValueChange={vi.fn()}
     />,
   );
+
+  return { updateInputDevice };
 }
 
 describe("<WebRtcStreamerInner />", () => {
@@ -96,5 +149,56 @@ describe("<WebRtcStreamerInner />", () => {
     expect(
       screen.getByRole("button", { name: "Select Device" }),
     ).not.toBeNull();
+  });
+
+  it("does not switch devices when the selector synchronizes on mount", async () => {
+    const { updateInputDevice } = renderStreamer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Device" }));
+    await screen.findByRole("button", { name: "Choose another camera" });
+
+    expect(updateInputDevice).not.toHaveBeenCalled();
+  });
+
+  it("persists a user-selected device only after switching succeeds", async () => {
+    let finishSwitch: (() => void) | undefined;
+    const updateInputDevice = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSwitch = resolve;
+        }),
+    );
+    renderStreamer({ updateInputDevice });
+    fireEvent.click(screen.getByRole("button", { name: "Select Device" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Choose another camera" }),
+    );
+
+    expect(updateInputDevice).toHaveBeenCalledWith("video", "new-video");
+    expect(persistDeviceIds).not.toHaveBeenCalled();
+
+    await act(async () => finishSwitch?.());
+    expect(persistDeviceIds).toHaveBeenCalledWith("test-key", {
+      video: "new-video",
+      audio: "old-audio",
+    });
+  });
+
+  it("shows a switching error and keeps the previous selection", async () => {
+    const updateInputDevice = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException("Device is busy", "NotReadableError"),
+      );
+    renderStreamer({ updateInputDevice });
+    fireEvent.click(screen.getByRole("button", { name: "Select Device" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Choose another camera" }),
+    );
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Device is busy",
+    );
+    expect(persistDeviceIds).not.toHaveBeenCalled();
   });
 });

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -51,9 +51,6 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     audio?: MediaDeviceInfo["deviceId"] | undefined;
   }>(() => loadPersistedDeviceIds(componentKey));
 
-  // Persist whenever the selection changes — both the DeviceSelect form's
-  // `onSelect` and the WebRTC hook's `onDevicesOpened` route through
-  // `setDeviceIds`, so this single effect covers both paths.
   const initialDeviceIdsRef = useRef(deviceIds);
   useEffect(() => {
     if (deviceIds === initialDeviceIdsRef.current) return;
@@ -127,14 +124,11 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   const closeDeviceSelect = useCallback(() => {
     setDeviceSelectOpen(false);
   }, []);
-  const selectDevices = useCallback(
-    (
-      nextDeviceIds: {
-        video?: MediaDeviceInfo["deviceId"];
-        audio?: MediaDeviceInfo["deviceId"];
-      },
-      changedKind?: "video" | "audio",
-    ) => {
+  const reconcileDeviceIds = useCallback(
+    (nextDeviceIds: {
+      video?: MediaDeviceInfo["deviceId"];
+      audio?: MediaDeviceInfo["deviceId"];
+    }) => {
       const devicesChanged =
         nextDeviceIds.video !== deviceIds.video ||
         nextDeviceIds.audio !== deviceIds.audio;
@@ -143,22 +137,32 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       }
       const isStreaming =
         state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
-      if (isStreaming && changedKind != null) {
-        const deviceId = nextDeviceIds[changedKind];
-        if (deviceId == null) {
-          return;
-        }
-        setDeviceSwitchError(null);
-        void updateInputDevice(changedKind, deviceId)
-          .then(() => setDeviceIds(nextDeviceIds))
-          .catch((error: unknown) =>
-            setDeviceSwitchError(
-              error instanceof Error ? error : new Error(String(error)),
-            ),
-          );
-      } else if (!isStreaming) {
+      if (!isStreaming) {
         setDeviceIds(nextDeviceIds);
       }
+    },
+    [deviceIds, state.webRtcState],
+  );
+  const selectInputDevice = useCallback(
+    (kind: "video" | "audio", deviceId: MediaDeviceInfo["deviceId"]) => {
+      if (deviceId === deviceIds[kind]) {
+        return;
+      }
+      const nextDeviceIds = { ...deviceIds, [kind]: deviceId };
+      const isStreaming =
+        state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
+      if (!isStreaming) {
+        setDeviceIds(nextDeviceIds);
+        return;
+      }
+      setDeviceSwitchError(null);
+      void updateInputDevice(kind, deviceId)
+        .then(() => setDeviceIds(nextDeviceIds))
+        .catch((error: unknown) =>
+          setDeviceSwitchError(
+            error instanceof Error ? error : new Error(String(error)),
+          ),
+        );
     },
     [deviceIds, state.webRtcState, updateInputDevice],
   );
@@ -170,7 +174,9 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
           audio={audioEnabled}
           defaultVideoDeviceId={deviceIds.video}
           defaultAudioDeviceId={deviceIds.audio}
-          onSelect={selectDevices}
+          onSelectionResolved={reconcileDeviceIds}
+          onVideoSelect={(deviceId) => selectInputDevice("video", deviceId)}
+          onAudioSelect={(deviceId) => selectInputDevice("audio", deviceId)}
           onClose={closeDeviceSelect}
           switchError={deviceSwitchError}
         />

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -76,7 +76,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     },
     [],
   );
-  const { state, start, stop, updateInputDevices } = useWebRtc(
+  const { state, start, stop, updateInputDevice } = useWebRtc(
     props,
     deviceIds.video,
     deviceIds.audio,
@@ -117,32 +117,50 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   );
 
   const [deviceSelectOpen, setDeviceSelectOpen] = useState(false);
+  const [deviceSwitchError, setDeviceSwitchError] = useState<Error | null>(
+    null,
+  );
   const openDeviceSelect = useCallback(() => {
+    setDeviceSwitchError(null);
     setDeviceSelectOpen(true);
   }, []);
   const closeDeviceSelect = useCallback(() => {
     setDeviceSelectOpen(false);
   }, []);
   const selectDevices = useCallback(
-    (nextDeviceIds: {
-      video: MediaDeviceInfo["deviceId"] | undefined;
-      audio: MediaDeviceInfo["deviceId"] | undefined;
-    }) => {
+    (
+      nextDeviceIds: {
+        video?: MediaDeviceInfo["deviceId"];
+        audio?: MediaDeviceInfo["deviceId"];
+      },
+      changedKind?: "video" | "audio",
+    ) => {
       const devicesChanged =
         nextDeviceIds.video !== deviceIds.video ||
         nextDeviceIds.audio !== deviceIds.audio;
-      if (
-        devicesChanged &&
-        (state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING")
-      ) {
-        void updateInputDevices(nextDeviceIds.video, nextDeviceIds.audio)
+      if (!devicesChanged) {
+        return;
+      }
+      const isStreaming =
+        state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
+      if (isStreaming && changedKind != null) {
+        const deviceId = nextDeviceIds[changedKind];
+        if (deviceId == null) {
+          return;
+        }
+        setDeviceSwitchError(null);
+        void updateInputDevice(changedKind, deviceId)
           .then(() => setDeviceIds(nextDeviceIds))
-          .catch((error) => console.error("Failed to switch devices", error));
-      } else {
+          .catch((error: unknown) =>
+            setDeviceSwitchError(
+              error instanceof Error ? error : new Error(String(error)),
+            ),
+          );
+      } else if (!isStreaming) {
         setDeviceIds(nextDeviceIds);
       }
     },
-    [deviceIds, state.webRtcState, updateInputDevices],
+    [deviceIds, state.webRtcState, updateInputDevice],
   );
   if (deviceSelectOpen) {
     return (
@@ -154,6 +172,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
           defaultAudioDeviceId={deviceIds.audio}
           onSelect={selectDevices}
           onClose={closeDeviceSelect}
+          switchError={deviceSwitchError}
         />
       </Suspense>
     );

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -144,27 +144,33 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     [deviceIds, state.webRtcState],
   );
   const selectInputDevice = useCallback(
-    (kind: "video" | "audio", deviceId: MediaDeviceInfo["deviceId"]) => {
-      if (deviceId === deviceIds[kind]) {
-        return;
-      }
-      const nextDeviceIds = { ...deviceIds, [kind]: deviceId };
+    async (
+      kind: "video" | "audio",
+      deviceId: MediaDeviceInfo["deviceId"],
+    ): Promise<void> => {
       const isStreaming =
         state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
       if (!isStreaming) {
-        setDeviceIds(nextDeviceIds);
+        setDeviceIds((prev) =>
+          prev[kind] === deviceId ? prev : { ...prev, [kind]: deviceId },
+        );
         return;
       }
       setDeviceSwitchError(null);
-      void updateInputDevice(kind, deviceId)
-        .then(() => setDeviceIds(nextDeviceIds))
-        .catch((error: unknown) =>
-          setDeviceSwitchError(
-            error instanceof Error ? error : new Error(String(error)),
-          ),
+      try {
+        await updateInputDevice(kind, deviceId);
+        setDeviceIds((prev) =>
+          prev[kind] === deviceId ? prev : { ...prev, [kind]: deviceId },
         );
+        setDeviceSwitchError(null);
+      } catch (error: unknown) {
+        const switchError =
+          error instanceof Error ? error : new Error(String(error));
+        setDeviceSwitchError(switchError);
+        throw switchError;
+      }
     },
-    [deviceIds, state.webRtcState, updateInputDevice],
+    [state.webRtcState, updateInputDevice],
   );
   if (deviceSelectOpen) {
     return (

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -76,7 +76,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     },
     [],
   );
-  const { state, start, stop } = useWebRtc(
+  const { state, start, stop, updateInputDevices } = useWebRtc(
     props,
     deviceIds.video,
     deviceIds.audio,
@@ -123,6 +123,27 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   const closeDeviceSelect = useCallback(() => {
     setDeviceSelectOpen(false);
   }, []);
+  const selectDevices = useCallback(
+    (nextDeviceIds: {
+      video: MediaDeviceInfo["deviceId"] | undefined;
+      audio: MediaDeviceInfo["deviceId"] | undefined;
+    }) => {
+      const devicesChanged =
+        nextDeviceIds.video !== deviceIds.video ||
+        nextDeviceIds.audio !== deviceIds.audio;
+      if (
+        devicesChanged &&
+        (state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING")
+      ) {
+        void updateInputDevices(nextDeviceIds.video, nextDeviceIds.audio)
+          .then(() => setDeviceIds(nextDeviceIds))
+          .catch((error) => console.error("Failed to switch devices", error));
+      } else {
+        setDeviceIds(nextDeviceIds);
+      }
+    },
+    [deviceIds, state.webRtcState, updateInputDevices],
+  );
   if (deviceSelectOpen) {
     return (
       <Suspense fallback={null}>
@@ -131,7 +152,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
           audio={audioEnabled}
           defaultVideoDeviceId={deviceIds.video}
           defaultAudioDeviceId={deviceIds.audio}
-          onSelect={setDeviceIds}
+          onSelect={selectDevices}
           onClose={closeDeviceSelect}
         />
       </Suspense>
@@ -196,16 +217,15 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
               />
             )}
           </Box>
-          {userControlsPlayingState &&
-            transmittable &&
-            state.webRtcState === "STOPPED" && (
-              <TranslatedButton
-                color="inherit"
-                onClick={openDeviceSelect}
-                translationKey="select_device"
-                defaultText="Select Device"
-              />
-            )}
+          {userControlsPlayingState && transmittable && (
+            <TranslatedButton
+              color="inherit"
+              onClick={openDeviceSelect}
+              disabled={buttonDisabled}
+              translationKey="select_device"
+              defaultText="Select Device"
+            />
+          )}
         </Box>
       )}
     </Box>

--- a/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
+++ b/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useWebRtc } from ".";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useWebRtc", () => {
+  it("rejects device switching without an active input stream", async () => {
+    const { result } = renderHook(() =>
+      useWebRtc(
+        {
+          mode: "SENDRECV",
+          desiredPlayingState: undefined,
+          sdpAnswerJson: undefined,
+          rtcConfiguration: undefined,
+          mediaStreamConstraints: { video: true, audio: true },
+          sendbackVideo: true,
+          sendbackAudio: true,
+        },
+        undefined,
+        undefined,
+        vi.fn(),
+        vi.fn(),
+      ),
+    );
+
+    await expect(
+      result.current.updateInputDevice("video", "next-video"),
+    ).rejects.toThrow(
+      "Cannot switch input device without an active WebRTC input stream",
+    );
+  });
+});

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -104,7 +104,9 @@ export const useWebRtc = (
     ): Promise<void> => {
       const pc = pcRef.current;
       if (pc == null || state.inputMediaStream == null) {
-        return;
+        throw new Error(
+          "Cannot switch input device without an active WebRTC input stream",
+        );
       }
       await switchInputDevice(
         pc,

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -3,6 +3,7 @@ import { compileMediaConstraints } from "../media-constraint";
 import { ComponentValue } from "../component-value";
 import { connectReducer, initialState } from "./reducer";
 import { useUniqueId } from "./use-unique-id";
+import { switchInputDevice, type InputDeviceKind } from "./switch-input-device";
 
 export type WebRtcMode = "RECVONLY" | "SENDONLY" | "SENDRECV";
 export const isWebRtcMode = (val: unknown): val is WebRtcMode =>
@@ -96,50 +97,25 @@ export const useWebRtc = (
   const stopRef = useRef(stop);
   stopRef.current = stop;
 
-  const updateInputDevices = useCallback(
+  const updateInputDevice = useCallback(
     async (
-      videoDeviceId: MediaDeviceInfo["deviceId"] | undefined,
-      audioDeviceId: MediaDeviceInfo["deviceId"] | undefined,
+      kind: InputDeviceKind,
+      deviceId: MediaDeviceInfo["deviceId"],
     ): Promise<void> => {
       const pc = pcRef.current;
       if (pc == null || state.inputMediaStream == null) {
         return;
       }
-
-      const constraints = compileMediaConstraints(
+      await switchInputDevice(
+        pc,
+        state.inputMediaStream,
         props.mediaStreamConstraints,
-        videoDeviceId,
-        audioDeviceId,
+        kind,
+        deviceId,
       );
-      const nextStream = await navigator.mediaDevices.getUserMedia(constraints);
-      const previousTracks = state.inputMediaStream.getTracks();
-
-      try {
-        await Promise.all(
-          nextStream.getTracks().map(async (nextTrack) => {
-            const sender = pc
-              .getSenders()
-              .find((candidate) => candidate.track?.kind === nextTrack.kind);
-            if (sender == null) {
-              throw new Error(`No sender found for ${nextTrack.kind} track`);
-            }
-
-            const previousTrack = sender.track;
-            if (previousTrack != null) {
-              nextTrack.enabled = previousTrack.enabled;
-            }
-            await sender.replaceTrack(nextTrack);
-          }),
-        );
-      } catch (error) {
-        nextStream.getTracks().forEach((track) => track.stop());
-        throw error;
-      }
-
-      previousTracks.forEach((track) => track.stop());
       dispatch({
         type: "SET_INPUT_MEDIA_STREAM",
-        inputMediaStream: nextStream,
+        inputMediaStream: state.inputMediaStream,
       });
     },
     [props.mediaStreamConstraints, state.inputMediaStream],
@@ -349,7 +325,7 @@ export const useWebRtc = (
   return {
     start,
     stop,
-    updateInputDevices,
+    updateInputDevice,
     state,
   };
 };

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -96,6 +96,55 @@ export const useWebRtc = (
   const stopRef = useRef(stop);
   stopRef.current = stop;
 
+  const updateInputDevices = useCallback(
+    async (
+      videoDeviceId: MediaDeviceInfo["deviceId"] | undefined,
+      audioDeviceId: MediaDeviceInfo["deviceId"] | undefined,
+    ): Promise<void> => {
+      const pc = pcRef.current;
+      if (pc == null || state.inputMediaStream == null) {
+        return;
+      }
+
+      const constraints = compileMediaConstraints(
+        props.mediaStreamConstraints,
+        videoDeviceId,
+        audioDeviceId,
+      );
+      const nextStream = await navigator.mediaDevices.getUserMedia(constraints);
+      const previousTracks = state.inputMediaStream.getTracks();
+
+      try {
+        await Promise.all(
+          nextStream.getTracks().map(async (nextTrack) => {
+            const sender = pc
+              .getSenders()
+              .find((candidate) => candidate.track?.kind === nextTrack.kind);
+            if (sender == null) {
+              throw new Error(`No sender found for ${nextTrack.kind} track`);
+            }
+
+            const previousTrack = sender.track;
+            if (previousTrack != null) {
+              nextTrack.enabled = previousTrack.enabled;
+            }
+            await sender.replaceTrack(nextTrack);
+          }),
+        );
+      } catch (error) {
+        nextStream.getTracks().forEach((track) => track.stop());
+        throw error;
+      }
+
+      previousTracks.forEach((track) => track.stop());
+      dispatch({
+        type: "SET_INPUT_MEDIA_STREAM",
+        inputMediaStream: nextStream,
+      });
+    },
+    [props.mediaStreamConstraints, state.inputMediaStream],
+  );
+
   const start = useCallback((): Promise<void> => {
     if (state.webRtcState !== "STOPPED") {
       return Promise.reject(new Error("WebRTC is already started"));
@@ -300,6 +349,7 @@ export const useWebRtc = (
   return {
     start,
     stop,
+    updateInputDevices,
     state,
   };
 };

--- a/streamlit_webrtc/frontend/src/webrtc/switch-input-device.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/switch-input-device.test.ts
@@ -137,4 +137,111 @@ describe("switchInputDevice", () => {
     expect(inputMediaStream.removeTrack).not.toHaveBeenCalled();
     expect(inputMediaStream.addTrack).not.toHaveBeenCalled();
   });
+
+  it("stops acquired tracks when the requested kind is missing", async () => {
+    const acquiredTrack = makeTrack("audio");
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(makeStream([acquiredTrack])),
+      },
+    });
+
+    await expect(
+      switchInputDevice(
+        { getSenders: () => [] },
+        makeStream([]),
+        { video: true, audio: true },
+        "video",
+        "next-video",
+      ),
+    ).rejects.toThrow("No video track acquired");
+
+    expect(acquiredTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it("stops the acquired track when no sender is available", async () => {
+    const nextTrack = makeTrack("video");
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(makeStream([nextTrack])),
+      },
+    });
+
+    await expect(
+      switchInputDevice(
+        { getSenders: () => [] },
+        makeStream([]),
+        { video: true, audio: true },
+        "video",
+        "next-video",
+      ),
+    ).rejects.toThrow("No sender found for video track");
+
+    expect(nextTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it("serializes overlapping switches of the same kind", async () => {
+    const previousTrack = makeTrack("video");
+    const firstTrack = makeTrack("video");
+    const secondTrack = makeTrack("video");
+    const inputMediaStream = makeStream([previousTrack]);
+    let finishFirstReplacement: (() => void) | undefined;
+    const sender = {
+      track: previousTrack,
+      replaceTrack: vi.fn((nextTrack: MediaStreamTrack) => {
+        if (nextTrack === firstTrack) {
+          return new Promise<void>((resolve) => {
+            finishFirstReplacement = () => {
+              sender.track = firstTrack;
+              resolve();
+            };
+          });
+        }
+        sender.track = nextTrack;
+        return Promise.resolve();
+      }),
+    };
+    const getUserMedia = vi
+      .fn()
+      .mockResolvedValueOnce(makeStream([firstTrack]))
+      .mockResolvedValueOnce(makeStream([secondTrack]));
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const peerConnection = {
+      getSenders: () => [sender as unknown as RTCRtpSender],
+    };
+
+    const firstSwitch = switchInputDevice(
+      peerConnection,
+      inputMediaStream,
+      { video: true, audio: true },
+      "video",
+      "first-video",
+    );
+    const secondSwitch = switchInputDevice(
+      peerConnection,
+      inputMediaStream,
+      { video: true, audio: true },
+      "video",
+      "second-video",
+    );
+
+    await vi.waitFor(() => expect(sender.replaceTrack).toHaveBeenCalledOnce());
+    expect(getUserMedia).toHaveBeenCalledOnce();
+
+    finishFirstReplacement?.();
+    await firstSwitch;
+    await secondSwitch;
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2);
+    expect(sender.replaceTrack).toHaveBeenNthCalledWith(1, firstTrack);
+    expect(sender.replaceTrack).toHaveBeenNthCalledWith(2, secondTrack);
+    expect(inputMediaStream.removeTrack).toHaveBeenNthCalledWith(
+      1,
+      previousTrack,
+    );
+    expect(inputMediaStream.removeTrack).toHaveBeenNthCalledWith(2, firstTrack);
+    expect(previousTrack.stop).toHaveBeenCalledOnce();
+    expect(firstTrack.stop).toHaveBeenCalledOnce();
+    expect(secondTrack.stop).not.toHaveBeenCalled();
+  });
 });

--- a/streamlit_webrtc/frontend/src/webrtc/switch-input-device.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/switch-input-device.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { switchInputDevice } from "./switch-input-device";
+
+function makeTrack(kind: "video" | "audio", enabled = true) {
+  return {
+    kind,
+    enabled,
+    stop: vi.fn(),
+  } as unknown as MediaStreamTrack;
+}
+
+function makeStream(tracks: MediaStreamTrack[]) {
+  return {
+    getTracks: () => tracks,
+    removeTrack: vi.fn(),
+    addTrack: vi.fn(),
+  } as unknown as MediaStream;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("switchInputDevice", () => {
+  it.each(["video", "audio"] as const)(
+    "acquires and replaces only the changed %s track",
+    async (kind) => {
+      const previousTrack = makeTrack(kind, false);
+      const unchangedTrack = makeTrack(kind === "video" ? "audio" : "video");
+      const nextTrack = makeTrack(kind);
+      const inputMediaStream = makeStream([previousTrack, unchangedTrack]);
+      const nextStream = makeStream([nextTrack]);
+      const replaceTrack = vi.fn().mockResolvedValue(undefined);
+      const getUserMedia = vi.fn().mockResolvedValue(nextStream);
+      vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+      await switchInputDevice(
+        {
+          getSenders: () => [
+            { track: previousTrack, replaceTrack } as unknown as RTCRtpSender,
+          ],
+        },
+        inputMediaStream,
+        { video: true, audio: true },
+        kind,
+        `${kind}-device`,
+      );
+
+      expect(getUserMedia).toHaveBeenCalledWith(
+        kind === "video"
+          ? {
+              video: { deviceId: { exact: "video-device" } },
+              audio: false,
+            }
+          : {
+              video: false,
+              audio: { deviceId: { exact: "audio-device" } },
+            },
+      );
+      expect(replaceTrack).toHaveBeenCalledWith(nextTrack);
+      expect(nextTrack.enabled).toBe(false);
+      expect(inputMediaStream.removeTrack).toHaveBeenCalledWith(previousTrack);
+      expect(inputMediaStream.addTrack).toHaveBeenCalledWith(nextTrack);
+      expect(previousTrack.stop).toHaveBeenCalledOnce();
+      expect(unchangedTrack.stop).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps the previous track alive until replacement succeeds", async () => {
+    const previousTrack = makeTrack("video");
+    const nextTrack = makeTrack("video");
+    const inputMediaStream = makeStream([previousTrack]);
+    const nextStream = makeStream([nextTrack]);
+    let finishReplacement: (() => void) | undefined;
+    const replaceTrack = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReplacement = resolve;
+        }),
+    );
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(nextStream),
+      },
+    });
+
+    const switching = switchInputDevice(
+      {
+        getSenders: () => [
+          { track: previousTrack, replaceTrack } as unknown as RTCRtpSender,
+        ],
+      },
+      inputMediaStream,
+      { video: true, audio: true },
+      "video",
+      "next-video",
+    );
+    await vi.waitFor(() => expect(replaceTrack).toHaveBeenCalledOnce());
+
+    expect(previousTrack.stop).not.toHaveBeenCalled();
+    finishReplacement?.();
+    await switching;
+    expect(previousTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up the new track and leaves the previous track active on failure", async () => {
+    const previousTrack = makeTrack("audio");
+    const nextTrack = makeTrack("audio");
+    const inputMediaStream = makeStream([previousTrack]);
+    const nextStream = makeStream([nextTrack]);
+    const error = new DOMException("Device is busy", "NotReadableError");
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(nextStream),
+      },
+    });
+
+    await expect(
+      switchInputDevice(
+        {
+          getSenders: () => [
+            {
+              track: previousTrack,
+              replaceTrack: vi.fn().mockRejectedValue(error),
+            } as unknown as RTCRtpSender,
+          ],
+        },
+        inputMediaStream,
+        { video: true, audio: true },
+        "audio",
+        "busy-audio",
+      ),
+    ).rejects.toBe(error);
+
+    expect(nextTrack.stop).toHaveBeenCalledOnce();
+    expect(previousTrack.stop).not.toHaveBeenCalled();
+    expect(inputMediaStream.removeTrack).not.toHaveBeenCalled();
+    expect(inputMediaStream.addTrack).not.toHaveBeenCalled();
+  });
+});

--- a/streamlit_webrtc/frontend/src/webrtc/switch-input-device.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/switch-input-device.ts
@@ -1,0 +1,54 @@
+import { compileMediaConstraints } from "../media-constraint";
+
+export type InputDeviceKind = "video" | "audio";
+
+export async function switchInputDevice(
+  peerConnection: Pick<RTCPeerConnection, "getSenders">,
+  inputMediaStream: MediaStream,
+  mediaStreamConstraints: MediaStreamConstraints | undefined,
+  kind: InputDeviceKind,
+  deviceId: MediaDeviceInfo["deviceId"],
+): Promise<void> {
+  const constraints = compileMediaConstraints(
+    mediaStreamConstraints,
+    kind === "video" ? deviceId : undefined,
+    kind === "audio" ? deviceId : undefined,
+  );
+  if (kind === "video") {
+    constraints.audio = false;
+  } else {
+    constraints.video = false;
+  }
+
+  const nextStream = await navigator.mediaDevices.getUserMedia(constraints);
+  const nextTrack = nextStream.getTracks().find((track) => track.kind === kind);
+  const sender = peerConnection
+    .getSenders()
+    .find((candidate) => candidate.track?.kind === kind);
+  const previousTrack = sender?.track;
+
+  if (nextTrack == null) {
+    nextStream.getTracks().forEach((track) => track.stop());
+    throw new Error(`No ${kind} track acquired`);
+  }
+  if (sender == null || previousTrack == null) {
+    nextStream.getTracks().forEach((track) => track.stop());
+    throw new Error(`No sender found for ${kind} track`);
+  }
+
+  nextTrack.enabled = previousTrack.enabled;
+  try {
+    await sender.replaceTrack(nextTrack);
+  } catch (error) {
+    nextStream.getTracks().forEach((track) => track.stop());
+    throw error;
+  }
+
+  inputMediaStream.removeTrack(previousTrack);
+  inputMediaStream.addTrack(nextTrack);
+  previousTrack.stop();
+  nextStream
+    .getTracks()
+    .filter((track) => track !== nextTrack)
+    .forEach((track) => track.stop());
+}

--- a/streamlit_webrtc/frontend/src/webrtc/switch-input-device.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/switch-input-device.ts
@@ -2,7 +2,12 @@ import { compileMediaConstraints } from "../media-constraint";
 
 export type InputDeviceKind = "video" | "audio";
 
-export async function switchInputDevice(
+const switchQueues = new WeakMap<
+  Pick<RTCPeerConnection, "getSenders">,
+  Partial<Record<InputDeviceKind, Promise<void>>>
+>();
+
+async function replaceInputDevice(
   peerConnection: Pick<RTCPeerConnection, "getSenders">,
   inputMediaStream: MediaStream,
   mediaStreamConstraints: MediaStreamConstraints | undefined,
@@ -51,4 +56,38 @@ export async function switchInputDevice(
     .getTracks()
     .filter((track) => track !== nextTrack)
     .forEach((track) => track.stop());
+}
+
+export function switchInputDevice(
+  peerConnection: Pick<RTCPeerConnection, "getSenders">,
+  inputMediaStream: MediaStream,
+  mediaStreamConstraints: MediaStreamConstraints | undefined,
+  kind: InputDeviceKind,
+  deviceId: MediaDeviceInfo["deviceId"],
+): Promise<void> {
+  const queues = switchQueues.get(peerConnection) ?? {};
+  switchQueues.set(peerConnection, queues);
+
+  const previousSwitch = queues[kind] ?? Promise.resolve();
+  const currentSwitch = previousSwitch
+    .catch(() => undefined)
+    .then(() =>
+      replaceInputDevice(
+        peerConnection,
+        inputMediaStream,
+        mediaStreamConstraints,
+        kind,
+        deviceId,
+      ),
+    );
+  queues[kind] = currentSwitch;
+
+  const removeCompletedSwitch = () => {
+    if (queues[kind] === currentSwitch) {
+      delete queues[kind];
+    }
+  };
+  void currentSwitch.then(removeCompletedSwitch, removeCompletedSwitch);
+
+  return currentSwitch;
 }


### PR DESCRIPTION
Closes #2555.

## What changed

- Keep the input device selector available while WebRTC is signalling or playing.
- Replace active camera and microphone sender tracks when the selection changes, without restarting or renegotiating the connection.
- Preserve each track's enabled state so camera-off and microphone-mute choices survive a device switch.
- Persist the selected device IDs only after live replacement succeeds.
- Add regression coverage and a changelog fragment.

## Why

The selector was previously rendered only while the component was stopped, and changing its values only affected the next WebRTC start. Users therefore had to stop streaming before choosing another camera or microphone.

## Validation

- `uv run --frozen pytest` (112 passed)
- `uv run --frozen pre-commit run --all-files`
- `pnpm run format`
- `pnpm run lint`
- `pnpm test -- --run` (31 passed)
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switch input cameras and microphones while streaming without restarting.
  * Device selection remains available during active streaming.
  * Persist selected devices after a successful switch.

* **Bug Fixes**
  * Improved device-switch behavior to keep the current device if switching fails.
  * Better handling of asynchronous track replacement and temporary media tracks.

* **Tests**
  * Added/updated test coverage for device switching, persistence behavior, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->