### PR TITLE
Fix device selection to actually switch the input device

### DIFF
--- a/changelog.d/20260713_003955_t.yic.yt_device_selection.md
+++ b/changelog.d/20260713_003955_t.yic.yt_device_selection.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Selecting a device in the device selection form now reliably switches the input device. The selected device ID was previously passed to `getUserMedia` as an "ideal" hint, which browsers could ignore and silently fall back to the default camera (e.g. the built-in camera instead of a selected Continuity Camera); it is now passed as an `exact` constraint, and the actually-opened device no longer overwrites an explicit user selection.

--- a/streamlit_webrtc/frontend/src/DeviceSelect/VideoPreview.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/VideoPreview.tsx
@@ -16,7 +16,12 @@ function VideoPreview(props: VideoPreviewProps) {
     let stream: MediaStream | null = null;
     let unmounted = false;
     navigator.mediaDevices
-      .getUserMedia({ video: { deviceId: props.deviceId }, audio: false })
+      .getUserMedia({
+        // `exact` so the preview shows the selected device, not a browser
+        // fallback — a bare deviceId is only an "ideal" hint.
+        video: { deviceId: { exact: props.deviceId } },
+        audio: false,
+      })
       .then((_stream) => {
         stream = _stream;
 

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -59,12 +59,29 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     if (deviceIds === initialDeviceIdsRef.current) return;
     persistDeviceIds(componentKey, deviceIds);
   }, [componentKey, deviceIds]);
+  // Record the devices that actually opened, but never overwrite an explicit
+  // selection — the opened device can be a browser-chosen fallback, and
+  // letting it replace the user's choice would silently revert (and persist)
+  // the wrong device.
+  const handleDevicesOpened = useCallback(
+    (openedDeviceIds: { video?: string; audio?: string }) => {
+      setDeviceIds((prev) => {
+        const video = prev.video ?? openedDeviceIds.video;
+        const audio = prev.audio ?? openedDeviceIds.audio;
+        if (video === prev.video && audio === prev.audio) {
+          return prev;
+        }
+        return { video, audio };
+      });
+    },
+    [],
+  );
   const { state, start, stop } = useWebRtc(
     props,
     deviceIds.video,
     deviceIds.audio,
     props.onComponentValueChange,
-    setDeviceIds,
+    handleDevicesOpened,
   );
 
   const {

--- a/streamlit_webrtc/frontend/src/media-constraint.ts
+++ b/streamlit_webrtc/frontend/src/media-constraint.ts
@@ -3,12 +3,16 @@ export function compileMediaConstraints(
   videoDeviceId: string | undefined,
   audioDeviceId: string | undefined,
 ): MediaStreamConstraints {
-  const constraints = src || {};
+  const constraints: MediaStreamConstraints = { ...src };
 
+  // `exact` is required here: a bare deviceId is only an "ideal" hint that
+  // browsers may ignore, silently falling back to the default camera
+  // (observed with macOS Continuity Camera).
+  // Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#deviceid
   if (videoDeviceId) {
     if (constraints.video === true) {
       constraints.video = {
-        deviceId: videoDeviceId,
+        deviceId: { exact: videoDeviceId },
       };
     } else if (
       typeof constraints.video === "object" ||
@@ -16,7 +20,7 @@ export function compileMediaConstraints(
     ) {
       constraints.video = {
         ...constraints.video,
-        deviceId: videoDeviceId,
+        deviceId: { exact: videoDeviceId },
       };
     }
   }
@@ -24,7 +28,7 @@ export function compileMediaConstraints(
   if (audioDeviceId) {
     if (constraints.audio === true) {
       constraints.audio = {
-        deviceId: audioDeviceId,
+        deviceId: { exact: audioDeviceId },
       };
     } else if (
       typeof constraints.audio === "object" ||
@@ -32,7 +36,7 @@ export function compileMediaConstraints(
     ) {
       constraints.audio = {
         ...constraints.audio,
-        deviceId: audioDeviceId,
+        deviceId: { exact: audioDeviceId },
       };
     }
   }

--- a/streamlit_webrtc/frontend/src/media-constraints.test.ts
+++ b/streamlit_webrtc/frontend/src/media-constraints.test.ts
@@ -9,13 +9,13 @@ describe("compileMediaConstraints()", () => {
       expect(compileMediaConstraints(src, undefined, undefined)).toEqual({});
     });
 
-    it("sets device IDs if provided", () => {
+    it("sets device IDs as exact constraints if provided", () => {
       expect(compileMediaConstraints(src, "videoid", "audioid")).toEqual({
         video: {
-          deviceId: "videoid",
+          deviceId: { exact: "videoid" },
         },
         audio: {
-          deviceId: "audioid",
+          deviceId: { exact: "audioid" },
         },
       });
     });
@@ -24,13 +24,13 @@ describe("compileMediaConstraints()", () => {
   describe("when the source object simply contains bool specs with true value", () => {
     const src: MediaStreamConstraints = { video: true, audio: true };
 
-    it("sets deviceIds if provided", () => {
+    it("sets deviceIds as exact constraints if provided", () => {
       expect(compileMediaConstraints(src, "videoid", "audioid")).toEqual({
         video: {
-          deviceId: "videoid",
+          deviceId: { exact: "videoid" },
         },
         audio: {
-          deviceId: "audioid",
+          deviceId: { exact: "audioid" },
         },
       });
     });
@@ -67,11 +67,26 @@ describe("compileMediaConstraints()", () => {
             min: 10,
             max: 20,
           },
-          deviceId: "videoid",
+          deviceId: { exact: "videoid" },
         },
         audio: {
           echoCancellation: true,
-          deviceId: "audioid",
+          deviceId: { exact: "audioid" },
+        },
+      });
+    });
+
+    it("does not mutate the source object", () => {
+      compileMediaConstraints(src, "videoid", "audioid");
+      expect(src).toEqual({
+        video: {
+          frameRate: {
+            min: 10,
+            max: 20,
+          },
+        },
+        audio: {
+          echoCancellation: true,
         },
       });
     });


### PR DESCRIPTION
## Summary

The device selection form correctly listed available devices, but selecting one didn't actually switch the capture device — e.g. on macOS with an iPhone connected via Continuity Camera, selecting the iPhone kept capturing from the built-in camera while the UI looked refreshed.

Two mechanisms combined to cause this:

1. **The deviceId was passed to `getUserMedia` as an "ideal" hint.** `compileMediaConstraints` emitted `{ deviceId: "<id>" }`; per the spec a bare deviceId is a non-binding preference the browser may ignore, and Chrome/Safari fall back to the default camera (Continuity Camera is especially prone to this). It is now passed as `{ deviceId: { exact: "<id>" } }`.
2. **The actually-opened device overwrote the user's selection.** The opened device's id was reported back through `onDevicesOpened` straight into `setDeviceIds`, so when the browser fell back to the built-in camera, the fallback id replaced (and persisted over) the explicit selection — latching it back to the wrong device. The handler now only fills in ids the user hasn't explicitly chosen; as a bonus, a partial open (e.g. video only) no longer wipes the other kind's stored selection.

Also:
- The in-picker `VideoPreview` uses the same `exact` constraint, so the preview can't show a fallback camera while claiming to preview the selected one.
- `compileMediaConstraints` no longer mutates the Python-provided constraints object (it previously baked the deviceId into `props.mediaStreamConstraints` in place).

Behavioral trade-off: with `exact`, a persisted id for a now-disconnected device makes `getUserMedia` fail with `OverconstrainedError` (surfaced in the UI) instead of silently using the default camera; the user recovers by picking another device in the selector.

## Test plan

- [x] `pnpm test` (31 tests, including updated `compileMediaConstraints` expectations and a new no-mutation test)
- [x] `tsc -b`, `eslint`, `prettier --check`
- [ ] Manual: on a MacBook with iPhone Continuity Camera, select the iPhone in the device picker and start — capture should switch to the iPhone (verified by the reporter's setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Device selection now reliably switches to the camera or microphone chosen by the user.
  - Prevented browser-selected fallback devices from overriding an explicit selection.
  - Improved video preview behavior to consistently display the selected camera.

- **Tests**
  - Updated coverage to verify exact device selection constraints and preserve existing media settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->