### PR TITLE
Fix the object detection demo blocking the script thread and preventing Ctrl-C shutdown

### DIFF
--- a/changelog.d/20260714_083000_whitphx_object_detection_demo_loop.md
+++ b/changelog.d/20260714_083000_whitphx_object_detection_demo_loop.md
@@ -1,0 +1,7 @@
+<!--
+A new scriv changelog fragment.
+-->
+
+### Fixed
+
+- Fixed the object-detection demo blocking the script thread on `result_queue.get()` without a timeout, which prevented the Streamlit process from shutting down on Ctrl-C (script threads are non-daemon and are only stopped cooperatively at Streamlit calls). The demo's label loop now polls with a timeout, bounds itself on `ctx.state.playing`, and makes a Streamlit call on every iteration so pending stop/rerun requests are honored. Apps that copied this loop pattern should apply the same change.

--- a/pages/1_object_detection.py
+++ b/pages/1_object_detection.py
@@ -6,7 +6,7 @@ https://github.com/robmarkcole/object-detection-app
 import logging
 import queue
 from pathlib import Path
-from typing import List, NamedTuple, Optional
+from typing import List, NamedTuple
 
 import aiortc
 import av
@@ -156,11 +156,10 @@ if st.checkbox("Show the detected labels", value=True):
         # Then the rendered video frames and the labels displayed here
         # are not strictly synchronized.
         while webrtc_ctx.state.playing:
-            result: Optional[List[Detection]]
             try:
                 result = result_queue.get(timeout=1.0)
             except queue.Empty:
-                result = None
+                result = []
             # Render on every iteration, even when no result arrived:
             # a Streamlit call is where pending stop/rerun requests are
             # honored, and a script thread that keeps blocking without one

--- a/pages/1_object_detection.py
+++ b/pages/1_object_detection.py
@@ -6,7 +6,7 @@ https://github.com/robmarkcole/object-detection-app
 import logging
 import queue
 from pathlib import Path
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 
 import aiortc
 import av
@@ -155,8 +155,16 @@ if st.checkbox("Show the detected labels", value=True):
         # in different threads asynchronously.
         # Then the rendered video frames and the labels displayed here
         # are not strictly synchronized.
-        while True:
-            result = result_queue.get()
+        while webrtc_ctx.state.playing:
+            result: Optional[List[Detection]]
+            try:
+                result = result_queue.get(timeout=1.0)
+            except queue.Empty:
+                result = None
+            # Render on every iteration, even when no result arrived:
+            # a Streamlit call is where pending stop/rerun requests are
+            # honored, and a script thread that keeps blocking without one
+            # prevents the server process from shutting down.
             labels_placeholder.table(result)
 
 st.markdown(


### PR DESCRIPTION
## Problem

`pages/1_object_detection.py` displayed detection labels with:

```python
while True:
    result = result_queue.get()
    labels_placeholder.table(result)
```

Once the stream stops feeding `result_queue` (e.g. the user presses Stop), the script thread blocks forever in `queue.get()`. Streamlit stops scripts cooperatively — a pending stop/rerun request is only honored at the next Streamlit call — so the blocked thread never exits. ScriptRunner threads are non-daemon, so on Ctrl-C the interpreter hangs in `threading._shutdown()` joining it, and the server process cannot stop.

Confirmed with a `faulthandler` dump of a stalled process:

```
Thread [ScriptRunner.scriptThread] (most recent call first):
  File ".../queue.py", line 202 in get
  File ".../pages/1_object_detection.py", line 159 in <module>
```

## Fix

The label loop now:

- polls with `result_queue.get(timeout=1.0)` instead of blocking indefinitely,
- bounds itself on `webrtc_ctx.state.playing` (the `on_change` callback mutates that same context object, so a stop from the browser ends the loop), and
- makes a Streamlit call on **every** iteration — including when no result arrived — so pending stop/rerun requests are always honored within ~1s.

Verified end-to-end with a live stream: the old pattern stalls on Ctrl-C both after stopping the stream and mid-play; the fixed pattern exits cleanly in both cases. The other examples were audited; no other unbounded blocking reads remain (`9_sendonly_video.py` / `10_sendonly_audio.py` already use `timeout=1` and break on empty).

Apps that copied this loop pattern should apply the same change.

Split out of #2561, which fixes the other, library-level cause of the same Ctrl-C stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the object-detection demo’s shutdown and rerun behavior in the “detected labels” view.
  * Prevented the demo from blocking indefinitely while waiting for inference results, ensuring responsiveness to stop requests (including Ctrl-C).
  * Updated result polling to use timeouts and render continuously, even when no new detections are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->