### PR TITLE
Fix `OverconstrainedError` when the remembered input device is gone

### DIFF
--- a/changelog.d/20260804_181310_t.yic.yt.md
+++ b/changelog.d/20260804_181310_t.yic.yt.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Starting a stream no longer fails with `OverconstrainedError` when the remembered input device is gone. Browsers reissue device IDs when site data or the camera permission is reset, and a device can be unplugged, so the capture is retried without the IDs that no longer resolve and the stored selection is updated to the device that opened.
+- Starting a stream no longer fails with `OverconstrainedError` when the remembered input device is gone. Browsers reissue device IDs when site data or the camera permission is reset, and a device can be unplugged, so the capture is retried without the IDs that no longer resolve, and the stored selection is updated to the device that opened, or cleared when none is available.

--- a/changelog.d/20260804_181310_t.yic.yt.md
+++ b/changelog.d/20260804_181310_t.yic.yt.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Starting a stream no longer fails with `OverconstrainedError` when the remembered input device is gone. Browsers reissue device IDs when site data or the camera permission is reset, and a device can be unplugged, so the capture is retried without the IDs that no longer resolve and the stored selection is updated to the device that opened.

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -130,9 +130,10 @@ function renderStreamer({
     />,
   );
 
-  const onDevicesOpened = vi.mocked(useWebRtc).mock.calls[0][4];
+  const [, , , , onDevicesOpened, onDevicesUnavailable] =
+    vi.mocked(useWebRtc).mock.calls[0];
 
-  return { updateInputDevice, onDevicesOpened };
+  return { updateInputDevice, onDevicesOpened, onDevicesUnavailable };
 }
 
 describe("<WebRtcStreamerInner />", () => {
@@ -203,24 +204,35 @@ describe("<WebRtcStreamerInner />", () => {
   it("keeps the stored selection when a fallback device opens", async () => {
     const { onDevicesOpened } = renderStreamer();
 
-    act(() => onDevicesOpened({ video: "fallback-video" }, []));
+    act(() => onDevicesOpened({ video: "fallback-video" }));
 
     expect(persistDeviceIds).not.toHaveBeenCalled();
   });
 
   it("replaces a stored ID whose device no longer exists", async () => {
-    const { onDevicesOpened } = renderStreamer();
+    const { onDevicesOpened, onDevicesUnavailable } = renderStreamer();
 
-    act(() =>
-      onDevicesOpened({ video: "fallback-video", audio: "old-audio" }, [
-        "video",
-      ]),
-    );
+    act(() => onDevicesUnavailable(["video"]));
+    act(() => onDevicesOpened({ video: "fallback-video" }));
 
-    expect(persistDeviceIds).toHaveBeenCalledWith(
+    expect(persistDeviceIds).toHaveBeenLastCalledWith(
       "test-key",
       { video: "fallback-video", audio: "old-audio" },
       { clearing: false },
+    );
+  });
+
+  it("drops a dead ID even when no replacement device opens", async () => {
+    const { onDevicesUnavailable } = renderStreamer();
+
+    // The capture that discovered this may still go on to fail; the ID has to
+    // go regardless, or every later start repeats the rejected request.
+    act(() => onDevicesUnavailable(["video"]));
+
+    expect(persistDeviceIds).toHaveBeenCalledWith(
+      "test-key",
+      { audio: "old-audio" },
+      { clearing: true },
     );
   });
 
@@ -241,10 +253,10 @@ describe("<WebRtcStreamerInner />", () => {
     );
   });
 
-  it("clears a stored ID when the retry opens no replacement", async () => {
-    const { onDevicesOpened } = renderStreamer();
+  it("removes the stored entry when every kind is gone", async () => {
+    const { onDevicesUnavailable } = renderStreamer();
 
-    act(() => onDevicesOpened({}, ["video", "audio"]));
+    act(() => onDevicesUnavailable(["video", "audio"]));
 
     // `clearing` is what carries this past the write guard, which would
     // otherwise read the empty selection as the not-opened-yet state and leave

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -185,10 +185,11 @@ describe("<WebRtcStreamerInner />", () => {
     expect(persistDeviceIds).not.toHaveBeenCalled();
 
     await act(async () => finishSwitch?.());
-    expect(persistDeviceIds).toHaveBeenCalledWith("test-key", {
-      video: "new-video",
-      audio: "old-audio",
-    });
+    expect(persistDeviceIds).toHaveBeenCalledWith(
+      "test-key",
+      { video: "new-video", audio: "old-audio" },
+      { clearing: false },
+    );
   });
 
   it("keeps the stored selection when a fallback device opens", async () => {
@@ -208,10 +209,26 @@ describe("<WebRtcStreamerInner />", () => {
       ]),
     );
 
-    expect(persistDeviceIds).toHaveBeenCalledWith("test-key", {
-      video: "fallback-video",
-      audio: "old-audio",
-    });
+    expect(persistDeviceIds).toHaveBeenCalledWith(
+      "test-key",
+      { video: "fallback-video", audio: "old-audio" },
+      { clearing: true },
+    );
+  });
+
+  it("clears a stored ID when the retry opens no replacement", async () => {
+    const { onDevicesOpened } = renderStreamer();
+
+    act(() => onDevicesOpened({}, ["video", "audio"]));
+
+    // `clearing` is what carries this past the write guard, which would
+    // otherwise read the empty selection as the not-opened-yet state and leave
+    // the dead IDs in storage for the next mount to retry.
+    expect(persistDeviceIds).toHaveBeenCalledWith(
+      "test-key",
+      { video: undefined, audio: undefined },
+      { clearing: true },
+    );
   });
 
   it("shows a switching error and keeps the previous selection", async () => {
@@ -255,18 +272,20 @@ describe("<WebRtcStreamerInner />", () => {
 
     await act(async () => finishAudioSwitch?.());
     await waitFor(() =>
-      expect(persistDeviceIds).toHaveBeenLastCalledWith("test-key", {
-        video: "old-video",
-        audio: "new-audio",
-      }),
+      expect(persistDeviceIds).toHaveBeenLastCalledWith(
+        "test-key",
+        { video: "old-video", audio: "new-audio" },
+        { clearing: false },
+      ),
     );
 
     await act(async () => finishVideoSwitch?.());
     await waitFor(() =>
-      expect(persistDeviceIds).toHaveBeenLastCalledWith("test-key", {
-        video: "new-video",
-        audio: "new-audio",
-      }),
+      expect(persistDeviceIds).toHaveBeenLastCalledWith(
+        "test-key",
+        { video: "new-video", audio: "new-audio" },
+        { clearing: false },
+      ),
     );
   });
 });

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -32,6 +32,11 @@ vi.mock("./device-storage", () => ({
   persistDeviceIds: vi.fn(),
 }));
 
+let resolvedSelection: { video?: string; audio?: string } = {
+  video: "old-video",
+  audio: "old-audio",
+};
+
 vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
   default: function MockDeviceSelectForm(props: {
     onSelectionResolved: (devices: { video?: string; audio?: string }) => void;
@@ -42,7 +47,7 @@ vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
     const { onSelectionResolved, onVideoSelect, onAudioSelect, switchError } =
       props;
     useEffect(() => {
-      onSelectionResolved({ video: "old-video", audio: "old-audio" });
+      onSelectionResolved(resolvedSelection);
     }, [onSelectionResolved]);
     const selectVideo = () => {
       void Promise.resolve(onVideoSelect("new-video")).catch(() => undefined);
@@ -67,6 +72,7 @@ vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  resolvedSelection = { video: "old-video", audio: "old-audio" };
 });
 
 function makeStream() {
@@ -80,11 +86,13 @@ function makeStream() {
 
 function renderStreamer({
   mediaToggleControls = true,
+  webRtcState = "PLAYING",
   updateInputDevice = vi
     .fn<(kind: "video" | "audio", deviceId: string) => Promise<void>>()
     .mockResolvedValue(undefined),
 }: {
   mediaToggleControls?: boolean;
+  webRtcState?: "STOPPED" | "PLAYING";
   updateInputDevice?: (
     kind: "video" | "audio",
     deviceId: string,
@@ -92,7 +100,7 @@ function renderStreamer({
 } = {}) {
   vi.mocked(useWebRtc).mockReturnValue({
     state: {
-      webRtcState: "PLAYING",
+      webRtcState,
       sdpOffer: null,
       iceCandidates: {},
       outputMediaStream: null,
@@ -212,7 +220,24 @@ describe("<WebRtcStreamerInner />", () => {
     expect(persistDeviceIds).toHaveBeenCalledWith(
       "test-key",
       { video: "fallback-video", audio: "old-audio" },
-      { clearing: true },
+      { clearing: false },
+    );
+  });
+
+  it("does not clear the stored selection when the picker resolves nothing", async () => {
+    // The picker resolves empty while its device list is still empty, which
+    // must not reach storage as a removal — the counterpart to the clearing
+    // case below.
+    resolvedSelection = {};
+    renderStreamer({ webRtcState: "STOPPED" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Device" }));
+    await screen.findByRole("button", { name: "Choose another camera" });
+
+    expect(persistDeviceIds).toHaveBeenCalledWith(
+      "test-key",
+      { video: undefined, audio: undefined },
+      { clearing: false },
     );
   });
 

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -122,7 +122,9 @@ function renderStreamer({
     />,
   );
 
-  return { updateInputDevice };
+  const onDevicesOpened = vi.mocked(useWebRtc).mock.calls[0][4];
+
+  return { updateInputDevice, onDevicesOpened };
 }
 
 describe("<WebRtcStreamerInner />", () => {
@@ -185,6 +187,29 @@ describe("<WebRtcStreamerInner />", () => {
     await act(async () => finishSwitch?.());
     expect(persistDeviceIds).toHaveBeenCalledWith("test-key", {
       video: "new-video",
+      audio: "old-audio",
+    });
+  });
+
+  it("keeps the stored selection when a fallback device opens", async () => {
+    const { onDevicesOpened } = renderStreamer();
+
+    act(() => onDevicesOpened({ video: "fallback-video" }, []));
+
+    expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
+  it("replaces a stored ID whose device no longer exists", async () => {
+    const { onDevicesOpened } = renderStreamer();
+
+    act(() =>
+      onDevicesOpened({ video: "fallback-video", audio: "old-audio" }, [
+        "video",
+      ]),
+    );
+
+    expect(persistDeviceIds).toHaveBeenCalledWith("test-key", {
+      video: "fallback-video",
       audio: "old-audio",
     });
   });

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -93,7 +93,9 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
         }
         return {
           deviceIds: { video, audio },
-          clearing: unavailableDeviceKinds.length > 0,
+          clearing: unavailableDeviceKinds.some(
+            (kind) => openedDeviceIds[kind] == null,
+          ),
         };
       });
     },

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -22,7 +22,11 @@ import {
 import { useTimer } from "./use-timeout";
 import { getMediaUsage } from "./media-constraint";
 import { ComponentValue, setComponentValue } from "./component-value";
-import { loadPersistedDeviceIds, persistDeviceIds } from "./device-storage";
+import {
+  loadPersistedDeviceIds,
+  persistDeviceIds,
+  type PersistedDeviceIds,
+} from "./device-storage";
 import TranslatedButton from "./translation/components/TranslatedButton";
 import InfoHeader from "./InfoHeader";
 
@@ -47,16 +51,25 @@ interface WebRtcStreamerInnerProps {
 }
 export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   const { componentKey } = props;
-  const [deviceIds, setDeviceIds] = useState<{
-    video?: MediaDeviceInfo["deviceId"] | undefined;
-    audio?: MediaDeviceInfo["deviceId"] | undefined;
-  }>(() => loadPersistedDeviceIds(componentKey));
+  const [selection, setSelection] = useState<{
+    deviceIds: PersistedDeviceIds;
+    // Whether the latest change dropped an ID because its device is gone. The
+    // storage write needs that to tell a deliberate removal apart from the
+    // empty selection it sees before any device has opened.
+    clearing: boolean;
+  }>(() => ({
+    deviceIds: loadPersistedDeviceIds(componentKey),
+    clearing: false,
+  }));
+  const deviceIds = selection.deviceIds;
 
-  const initialDeviceIdsRef = useRef(deviceIds);
+  const initialSelectionRef = useRef(selection);
   useEffect(() => {
-    if (deviceIds === initialDeviceIdsRef.current) return;
-    persistDeviceIds(componentKey, deviceIds);
-  }, [componentKey, deviceIds]);
+    if (selection === initialSelectionRef.current) return;
+    persistDeviceIds(componentKey, selection.deviceIds, {
+      clearing: selection.clearing,
+    });
+  }, [componentKey, selection]);
   // Record the devices that actually opened, but never overwrite an explicit
   // selection — the opened device can be a browser-chosen fallback, and
   // letting it replace the user's choice would silently revert (and persist)
@@ -68,17 +81,20 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       openedDeviceIds: { video?: string; audio?: string },
       unavailableDeviceKinds: InputDeviceKind[],
     ) => {
-      setDeviceIds((prev) => {
+      setSelection((prev) => {
         const resolve = (kind: InputDeviceKind) =>
           unavailableDeviceKinds.includes(kind)
             ? openedDeviceIds[kind]
-            : (prev[kind] ?? openedDeviceIds[kind]);
+            : (prev.deviceIds[kind] ?? openedDeviceIds[kind]);
         const video = resolve("video");
         const audio = resolve("audio");
-        if (video === prev.video && audio === prev.audio) {
+        if (video === prev.deviceIds.video && audio === prev.deviceIds.audio) {
           return prev;
         }
-        return { video, audio };
+        return {
+          deviceIds: { video, audio },
+          clearing: unavailableDeviceKinds.length > 0,
+        };
       });
     },
     [],
@@ -148,7 +164,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       const isStreaming =
         state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
       if (!isStreaming) {
-        setDeviceIds(nextDeviceIds);
+        setSelection({ deviceIds: nextDeviceIds, clearing: false });
       }
     },
     [deviceIds, state.webRtcState],
@@ -161,16 +177,26 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       const isStreaming =
         state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
       if (!isStreaming) {
-        setDeviceIds((prev) =>
-          prev[kind] === deviceId ? prev : { ...prev, [kind]: deviceId },
+        setSelection((prev) =>
+          prev.deviceIds[kind] === deviceId
+            ? prev
+            : {
+                deviceIds: { ...prev.deviceIds, [kind]: deviceId },
+                clearing: false,
+              },
         );
         return;
       }
       setDeviceSwitchError(null);
       try {
         await updateInputDevice(kind, deviceId);
-        setDeviceIds((prev) =>
-          prev[kind] === deviceId ? prev : { ...prev, [kind]: deviceId },
+        setSelection((prev) =>
+          prev.deviceIds[kind] === deviceId
+            ? prev
+            : {
+                deviceIds: { ...prev.deviceIds, [kind]: deviceId },
+                clearing: false,
+              },
         );
         setDeviceSwitchError(null);
       } catch (error: unknown) {

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -73,30 +73,36 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   // Record the devices that actually opened, but never overwrite an explicit
   // selection — the opened device can be a browser-chosen fallback, and
   // letting it replace the user's choice would silently revert (and persist)
-  // the wrong device. A kind reported as unavailable is the exception: its
-  // stored ID names a device that no longer exists, so keeping it would fail
-  // every subsequent start and leave the picker pointing at a dead entry.
+  // the wrong device.
   const handleDevicesOpened = useCallback(
-    (
-      openedDeviceIds: { video?: string; audio?: string },
-      unavailableDeviceKinds: InputDeviceKind[],
-    ) => {
+    (openedDeviceIds: { video?: string; audio?: string }) => {
       setSelection((prev) => {
-        const resolve = (kind: InputDeviceKind) =>
-          unavailableDeviceKinds.includes(kind)
-            ? openedDeviceIds[kind]
-            : (prev.deviceIds[kind] ?? openedDeviceIds[kind]);
-        const video = resolve("video");
-        const audio = resolve("audio");
+        const video = prev.deviceIds.video ?? openedDeviceIds.video;
+        const audio = prev.deviceIds.audio ?? openedDeviceIds.audio;
         if (video === prev.deviceIds.video && audio === prev.deviceIds.audio) {
           return prev;
         }
-        return {
-          deviceIds: { video, audio },
-          clearing: unavailableDeviceKinds.some(
-            (kind) => openedDeviceIds[kind] == null,
-          ),
-        };
+        return { deviceIds: { video, audio }, clearing: false };
+      });
+    },
+    [],
+  );
+  // A remembered ID for one of these kinds names a device that no longer
+  // exists. Keeping it would reject every subsequent start and leave the
+  // picker pointing at a dead entry, so it goes even when the capture that
+  // discovered this went on to fail.
+  const handleDevicesUnavailable = useCallback(
+    (unavailableDeviceKinds: InputDeviceKind[]) => {
+      setSelection((prev) => {
+        const cleared = unavailableDeviceKinds.filter(
+          (kind) => prev.deviceIds[kind] != null,
+        );
+        if (cleared.length === 0) {
+          return prev;
+        }
+        const deviceIds = { ...prev.deviceIds };
+        cleared.forEach((kind) => delete deviceIds[kind]);
+        return { deviceIds, clearing: true };
       });
     },
     [],
@@ -107,6 +113,7 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     deviceIds.audio,
     props.onComponentValueChange,
     handleDevicesOpened,
+    handleDevicesUnavailable,
   );
 
   const {

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -17,6 +17,7 @@ import {
   isWebRtcMode,
   isReceivable,
   isTransmittable,
+  type InputDeviceKind,
 } from "./webrtc";
 import { useTimer } from "./use-timeout";
 import { getMediaUsage } from "./media-constraint";
@@ -59,12 +60,21 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   // Record the devices that actually opened, but never overwrite an explicit
   // selection — the opened device can be a browser-chosen fallback, and
   // letting it replace the user's choice would silently revert (and persist)
-  // the wrong device.
+  // the wrong device. A kind reported as unavailable is the exception: its
+  // stored ID names a device that no longer exists, so keeping it would fail
+  // every subsequent start and leave the picker pointing at a dead entry.
   const handleDevicesOpened = useCallback(
-    (openedDeviceIds: { video?: string; audio?: string }) => {
+    (
+      openedDeviceIds: { video?: string; audio?: string },
+      unavailableDeviceKinds: InputDeviceKind[],
+    ) => {
       setDeviceIds((prev) => {
-        const video = prev.video ?? openedDeviceIds.video;
-        const audio = prev.audio ?? openedDeviceIds.audio;
+        const resolve = (kind: InputDeviceKind) =>
+          unavailableDeviceKinds.includes(kind)
+            ? openedDeviceIds[kind]
+            : (prev[kind] ?? openedDeviceIds[kind]);
+        const video = resolve("video");
+        const audio = resolve("audio");
         if (video === prev.video && audio === prev.audio) {
           return prev;
         }

--- a/streamlit_webrtc/frontend/src/device-storage.test.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.test.ts
@@ -108,6 +108,22 @@ describe("device-storage", () => {
       ).toEqual({ video: "vid", audio: "aud" });
     });
 
+    it("writes an empty selection when it clears devices that are gone", () => {
+      window.localStorage.setItem(
+        perComponentKey("myKey"),
+        JSON.stringify({ video: "vid", audio: "aud" }),
+      );
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid", audio: "aud" }),
+      );
+      persistDeviceIds("myKey", {}, { clearing: true });
+      expect(JSON.parse(window.localStorage.getItem(GLOBAL_KEY)!)).toEqual({});
+      expect(
+        JSON.parse(window.localStorage.getItem(perComponentKey("myKey"))!),
+      ).toEqual({});
+    });
+
     it("swallows storage errors", () => {
       const setItem = vi
         .spyOn(Storage.prototype, "setItem")

--- a/streamlit_webrtc/frontend/src/device-storage.test.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.test.ts
@@ -108,7 +108,7 @@ describe("device-storage", () => {
       ).toEqual({ video: "vid", audio: "aud" });
     });
 
-    it("writes an empty selection when it clears devices that are gone", () => {
+    it("removes the entries when it clears devices that are gone", () => {
       window.localStorage.setItem(
         perComponentKey("myKey"),
         JSON.stringify({ video: "vid", audio: "aud" }),
@@ -118,10 +118,19 @@ describe("device-storage", () => {
         JSON.stringify({ video: "vid", audio: "aud" }),
       );
       persistDeviceIds("myKey", {}, { clearing: true });
-      expect(JSON.parse(window.localStorage.getItem(GLOBAL_KEY)!)).toEqual({});
-      expect(
-        JSON.parse(window.localStorage.getItem(perComponentKey("myKey"))!),
-      ).toEqual({});
+      expect(window.localStorage.getItem(GLOBAL_KEY)).toBeNull();
+      expect(window.localStorage.getItem(perComponentKey("myKey"))).toBeNull();
+    });
+
+    it("leaves a cleared component reading the global fallback", () => {
+      persistDeviceIds("myKey", {}, { clearing: true });
+      window.localStorage.setItem(
+        GLOBAL_KEY,
+        JSON.stringify({ video: "vid-from-another-component" }),
+      );
+      expect(loadPersistedDeviceIds("myKey")).toEqual({
+        video: "vid-from-another-component",
+      });
     });
 
     it("swallows storage errors", () => {

--- a/streamlit_webrtc/frontend/src/device-storage.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.ts
@@ -69,18 +69,38 @@ export function loadPersistedDeviceIds(
   return read(GLOBAL_KEY) ?? {};
 }
 
+function remove(key: string): void {
+  const storage = safeLocalStorage();
+  if (storage == null) return;
+  try {
+    storage.removeItem(key);
+  } catch {
+    // SecurityError, etc. — persistence is best-effort.
+  }
+}
+
 export function persistDeviceIds(
   componentKey: string | undefined,
   deviceIds: PersistedDeviceIds,
   { clearing }: { clearing: boolean } = { clearing: false },
 ): void {
-  // A selection with no usable IDs is normally the brief window before devices
-  // are opened, and writing it would clobber a stored choice that is still
-  // good. `clearing` marks the other case, where the IDs were dropped because
-  // their devices no longer exist, which does have to reach storage.
-  if (!clearing && deviceIds.video == null && deviceIds.audio == null) return;
-  write(GLOBAL_KEY, deviceIds);
+  const keys = [GLOBAL_KEY];
   if (componentKey != null) {
-    write(PER_COMPONENT_PREFIX + componentKey, deviceIds);
+    keys.push(PER_COMPONENT_PREFIX + componentKey);
   }
+
+  if (deviceIds.video == null && deviceIds.audio == null) {
+    // An empty selection is normally the brief window before devices are
+    // opened, and writing it would clobber a stored choice that is still good.
+    // `clearing` marks the other case, where the IDs were dropped because
+    // their devices no longer exist.
+    if (!clearing) return;
+    // Removed rather than stored as an empty entry, which would count as a
+    // per-component selection and cut this component off from the global
+    // fallback for good.
+    keys.forEach(remove);
+    return;
+  }
+
+  keys.forEach((key) => write(key, deviceIds));
 }

--- a/streamlit_webrtc/frontend/src/device-storage.ts
+++ b/streamlit_webrtc/frontend/src/device-storage.ts
@@ -72,10 +72,13 @@ export function loadPersistedDeviceIds(
 export function persistDeviceIds(
   componentKey: string | undefined,
   deviceIds: PersistedDeviceIds,
+  { clearing }: { clearing: boolean } = { clearing: false },
 ): void {
-  // Skip writing an entry with no usable IDs to avoid clobbering an existing
-  // selection with `{}` during the brief window before devices are opened.
-  if (deviceIds.video == null && deviceIds.audio == null) return;
+  // A selection with no usable IDs is normally the brief window before devices
+  // are opened, and writing it would clobber a stored choice that is still
+  // good. `clearing` marks the other case, where the IDs were dropped because
+  // their devices no longer exist, which does have to reach storage.
+  if (!clearing && deviceIds.video == null && deviceIds.audio == null) return;
   write(GLOBAL_KEY, deviceIds);
   if (componentKey != null) {
     write(PER_COMPONENT_PREFIX + componentKey, deviceIds);

--- a/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
+++ b/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
@@ -23,6 +23,7 @@ describe("useWebRtc", () => {
         undefined,
         vi.fn(),
         vi.fn(),
+        vi.fn(),
       ),
     );
 

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -28,10 +28,11 @@ export const useWebRtc = (
   videoDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
   audioDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
   onComponentValueChange: (newComponentValue: ComponentValue) => void,
-  onDevicesOpened: (
-    openedDeviceIds: { video?: string; audio?: string },
-    unavailableDeviceKinds: InputDeviceKind[],
-  ) => void,
+  onDevicesOpened: (openedDeviceIds: {
+    video?: string;
+    audio?: string;
+  }) => void,
+  onDevicesUnavailable: (unavailableDeviceKinds: InputDeviceKind[]) => void,
 ) => {
   // Initialize component value
   useEffect(() => {
@@ -156,15 +157,14 @@ export const useWebRtc = (
 
       // Set up transceivers
       if (mode === "SENDRECV" || mode === "SENDONLY") {
-        const opened = await openInputMediaStream(
+        const inputMediaStream = await openInputMediaStream(
           props.mediaStreamConstraints,
           videoDeviceIdRequest,
           audioDeviceIdRequest,
+          onDevicesUnavailable,
         );
 
-        if (opened != null) {
-          const { stream: inputMediaStream, unavailableDeviceKinds } = opened;
-
+        if (inputMediaStream != null) {
           const openedDeviceIds: {
             video?: MediaDeviceInfo["deviceId"];
             audio?: MediaDeviceInfo["deviceId"];
@@ -183,11 +183,8 @@ export const useWebRtc = (
             }
             openedDeviceIds[kind] = deviceId;
           });
-          if (
-            Object.keys(openedDeviceIds).length > 0 ||
-            unavailableDeviceKinds.length > 0
-          ) {
-            onDevicesOpened(openedDeviceIds, unavailableDeviceKinds);
+          if (Object.keys(openedDeviceIds).length > 0) {
+            onDevicesOpened(openedDeviceIds);
           }
         }
 
@@ -279,6 +276,7 @@ export const useWebRtc = (
     props.sendbackAudio,
     state.webRtcState,
     onDevicesOpened,
+    onDevicesUnavailable,
     uniqueIdGenerator,
   ]);
 

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -1,9 +1,11 @@
 import { useReducer, useCallback, useRef, useEffect, useMemo } from "react";
-import { compileMediaConstraints } from "../media-constraint";
 import { ComponentValue } from "../component-value";
 import { connectReducer, initialState } from "./reducer";
 import { useUniqueId } from "./use-unique-id";
+import { openInputMediaStream } from "./open-input-media-stream";
 import { switchInputDevice, type InputDeviceKind } from "./switch-input-device";
+
+export type { InputDeviceKind };
 
 export type WebRtcMode = "RECVONLY" | "SENDONLY" | "SENDRECV";
 export const isWebRtcMode = (val: unknown): val is WebRtcMode =>
@@ -26,10 +28,10 @@ export const useWebRtc = (
   videoDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
   audioDeviceIdRequest: MediaDeviceInfo["deviceId"] | undefined,
   onComponentValueChange: (newComponentValue: ComponentValue) => void,
-  onDevicesOpened: (openedDeviceIds: {
-    video?: string;
-    audio?: string;
-  }) => void,
+  onDevicesOpened: (
+    openedDeviceIds: { video?: string; audio?: string },
+    unavailableDeviceKinds: InputDeviceKind[],
+  ) => void,
 ) => {
   // Initialize component value
   useEffect(() => {
@@ -154,31 +156,19 @@ export const useWebRtc = (
 
       // Set up transceivers
       if (mode === "SENDRECV" || mode === "SENDONLY") {
-        const constraints = compileMediaConstraints(
+        const opened = await openInputMediaStream(
           props.mediaStreamConstraints,
           videoDeviceIdRequest,
           audioDeviceIdRequest,
         );
-        console.debug("MediaStreamConstraints:", constraints);
 
-        if (constraints.audio || constraints.video) {
-          if (navigator.mediaDevices == null) {
-            // Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#privacy_and_security
-            // > A secure context is, in short, a page loaded using HTTPS or the file:/// URL scheme, or a page loaded from localhost.
-            throw new Error(
-              "navigator.mediaDevices is undefined. It seems the current document is not loaded securely.",
-            );
-          }
-          if (navigator.mediaDevices.getUserMedia == null) {
-            throw new Error("getUserMedia is not implemented in this browser");
-          }
+        if (opened != null) {
+          const { stream: inputMediaStream, unavailableDeviceKinds } = opened;
 
           const openedDeviceIds: {
             video?: MediaDeviceInfo["deviceId"];
             audio?: MediaDeviceInfo["deviceId"];
           } = {};
-          const inputMediaStream =
-            await navigator.mediaDevices.getUserMedia(constraints);
           dispatch({ type: "SET_INPUT_MEDIA_STREAM", inputMediaStream });
           inputMediaStream.getTracks().forEach((track) => {
             pc.addTrack(track, inputMediaStream);
@@ -193,8 +183,11 @@ export const useWebRtc = (
             }
             openedDeviceIds[kind] = deviceId;
           });
-          if (Object.keys(openedDeviceIds).length > 0) {
-            onDevicesOpened(openedDeviceIds);
+          if (
+            Object.keys(openedDeviceIds).length > 0 ||
+            unavailableDeviceKinds.length > 0
+          ) {
+            onDevicesOpened(openedDeviceIds, unavailableDeviceKinds);
           }
         }
 

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { openInputMediaStream } from "./open-input-media-stream";
+
+const STALE_VIDEO_ID = "stale-video";
+const LIVE_VIDEO_ID = "live-video";
+const LIVE_AUDIO_ID = "live-audio";
+
+function makeStream(): MediaStream {
+  return { getTracks: () => [] } as unknown as MediaStream;
+}
+
+function makeDevice(kind: MediaDeviceKind, deviceId: string): MediaDeviceInfo {
+  return { kind, deviceId, groupId: "", label: deviceId } as MediaDeviceInfo;
+}
+
+function overconstrainedError(): Error {
+  const error = new Error("Requested device not found");
+  error.name = "OverconstrainedError";
+  return error;
+}
+
+const getUserMedia = vi.fn<() => Promise<MediaStream>>();
+const enumerateDevices = vi.fn<() => Promise<MediaDeviceInfo[]>>();
+
+beforeEach(() => {
+  vi.stubGlobal("navigator", {
+    mediaDevices: { getUserMedia, enumerateDevices },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetAllMocks();
+});
+
+describe("openInputMediaStream()", () => {
+  it("returns null when the constraints ask for no media", async () => {
+    expect(
+      await openInputMediaStream(
+        { video: false, audio: false },
+        undefined,
+        undefined,
+      ),
+    ).toBeNull();
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("opens the requested devices without a retry when they resolve", async () => {
+    const stream = makeStream();
+    getUserMedia.mockResolvedValue(stream);
+
+    const opened = await openInputMediaStream(
+      { video: true, audio: false },
+      LIVE_VIDEO_ID,
+      undefined,
+    );
+
+    expect(opened).toEqual({ stream, unavailableDeviceKinds: [] });
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(getUserMedia).toHaveBeenCalledWith({
+      video: { deviceId: { exact: LIVE_VIDEO_ID } },
+      audio: false,
+    });
+    expect(enumerateDevices).not.toHaveBeenCalled();
+  });
+
+  it("retries without a device ID that no longer resolves", async () => {
+    const stream = makeStream();
+    getUserMedia
+      .mockRejectedValueOnce(overconstrainedError())
+      .mockResolvedValueOnce(stream);
+    enumerateDevices.mockResolvedValue([
+      makeDevice("videoinput", LIVE_VIDEO_ID),
+    ]);
+
+    const opened = await openInputMediaStream(
+      { video: true, audio: false },
+      STALE_VIDEO_ID,
+      undefined,
+    );
+
+    expect(opened).toEqual({ stream, unavailableDeviceKinds: ["video"] });
+    expect(getUserMedia).toHaveBeenLastCalledWith({
+      video: true,
+      audio: false,
+    });
+  });
+
+  it("keeps a device ID that still resolves while dropping the dead one", async () => {
+    getUserMedia
+      .mockRejectedValueOnce(overconstrainedError())
+      .mockResolvedValueOnce(makeStream());
+    enumerateDevices.mockResolvedValue([
+      makeDevice("videoinput", LIVE_VIDEO_ID),
+      makeDevice("audioinput", LIVE_AUDIO_ID),
+    ]);
+
+    const opened = await openInputMediaStream(
+      { video: true, audio: true },
+      STALE_VIDEO_ID,
+      LIVE_AUDIO_ID,
+    );
+
+    expect(opened?.unavailableDeviceKinds).toEqual(["video"]);
+    expect(getUserMedia).toHaveBeenLastCalledWith({
+      video: true,
+      audio: { deviceId: { exact: LIVE_AUDIO_ID } },
+    });
+  });
+
+  it("rethrows when every requested device exists, so another constraint is at fault", async () => {
+    const error = overconstrainedError();
+    getUserMedia.mockRejectedValue(error);
+    enumerateDevices.mockResolvedValue([
+      makeDevice("videoinput", LIVE_VIDEO_ID),
+    ]);
+
+    await expect(
+      openInputMediaStream(
+        { video: { frameRate: { exact: 1000 } } },
+        LIVE_VIDEO_ID,
+        undefined,
+      ),
+    ).rejects.toBe(error);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry errors other than OverconstrainedError", async () => {
+    const error = new DOMException("Permission denied", "NotAllowedError");
+    getUserMedia.mockRejectedValue(error);
+
+    await expect(
+      openInputMediaStream({ video: true }, STALE_VIDEO_ID, undefined),
+    ).rejects.toBe(error);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(enumerateDevices).not.toHaveBeenCalled();
+  });
+
+  it("drops every requested ID when the device list is unreadable", async () => {
+    getUserMedia
+      .mockRejectedValueOnce(overconstrainedError())
+      .mockResolvedValueOnce(makeStream());
+    enumerateDevices.mockRejectedValue(new Error("enumeration failed"));
+
+    const opened = await openInputMediaStream(
+      { video: true, audio: true },
+      STALE_VIDEO_ID,
+      LIVE_AUDIO_ID,
+    );
+
+    expect(opened?.unavailableDeviceKinds).toEqual(["video", "audio"]);
+    expect(getUserMedia).toHaveBeenLastCalledWith({
+      video: true,
+      audio: true,
+    });
+  });
+
+  it("rethrows when no device ID was requested at all", async () => {
+    const error = overconstrainedError();
+    getUserMedia.mockRejectedValue(error);
+
+    await expect(
+      openInputMediaStream({ video: true }, undefined, undefined),
+    ).rejects.toBe(error);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+});

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
@@ -125,6 +125,40 @@ describe("openInputMediaStream()", () => {
     expect(getUserMedia).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a stored ID for a kind the app disabled", async () => {
+    const error = overconstrainedError();
+    getUserMedia.mockRejectedValue(error);
+    enumerateDevices.mockResolvedValue([
+      makeDevice("videoinput", LIVE_VIDEO_ID),
+    ]);
+
+    // `audio: false` means the stale audio ID never reached the constraints,
+    // so it cannot be what the browser rejected.
+    await expect(
+      openInputMediaStream(
+        { video: true, audio: false },
+        LIVE_VIDEO_ID,
+        "stale-audio",
+      ),
+    ).rejects.toBe(error);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a device ID that the app itself constrained", async () => {
+    const error = overconstrainedError();
+    getUserMedia.mockRejectedValue(error);
+    enumerateDevices.mockResolvedValue([]);
+
+    await expect(
+      openInputMediaStream(
+        { video: { deviceId: { exact: "app-chosen-video" } } },
+        undefined,
+        undefined,
+      ),
+    ).rejects.toBe(error);
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry errors other than OverconstrainedError", async () => {
     const error = new DOMException("Permission denied", "NotAllowedError");
     getUserMedia.mockRejectedValue(error);

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.test.ts
@@ -21,6 +21,7 @@ function overconstrainedError(): Error {
 
 const getUserMedia = vi.fn<() => Promise<MediaStream>>();
 const enumerateDevices = vi.fn<() => Promise<MediaDeviceInfo[]>>();
+const onUnavailableDevices = vi.fn();
 
 beforeEach(() => {
   vi.stubGlobal("navigator", {
@@ -40,6 +41,7 @@ describe("openInputMediaStream()", () => {
         { video: false, audio: false },
         undefined,
         undefined,
+        onUnavailableDevices,
       ),
     ).toBeNull();
     expect(getUserMedia).not.toHaveBeenCalled();
@@ -53,15 +55,17 @@ describe("openInputMediaStream()", () => {
       { video: true, audio: false },
       LIVE_VIDEO_ID,
       undefined,
+      onUnavailableDevices,
     );
 
-    expect(opened).toEqual({ stream, unavailableDeviceKinds: [] });
+    expect(opened).toBe(stream);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
     expect(getUserMedia).toHaveBeenCalledWith({
       video: { deviceId: { exact: LIVE_VIDEO_ID } },
       audio: false,
     });
     expect(enumerateDevices).not.toHaveBeenCalled();
+    expect(onUnavailableDevices).not.toHaveBeenCalled();
   });
 
   it("retries without a device ID that no longer resolves", async () => {
@@ -77,13 +81,35 @@ describe("openInputMediaStream()", () => {
       { video: true, audio: false },
       STALE_VIDEO_ID,
       undefined,
+      onUnavailableDevices,
     );
 
-    expect(opened).toEqual({ stream, unavailableDeviceKinds: ["video"] });
+    expect(opened).toBe(stream);
+    expect(onUnavailableDevices).toHaveBeenCalledWith(["video"]);
     expect(getUserMedia).toHaveBeenLastCalledWith({
       video: true,
       audio: false,
     });
+  });
+
+  it("reports the dead device even when the retry fails too", async () => {
+    const fallbackError = new DOMException("No camera", "NotFoundError");
+    getUserMedia
+      .mockRejectedValueOnce(overconstrainedError())
+      .mockRejectedValueOnce(fallbackError);
+    enumerateDevices.mockResolvedValue([]);
+
+    await expect(
+      openInputMediaStream(
+        { video: true },
+        STALE_VIDEO_ID,
+        undefined,
+        onUnavailableDevices,
+      ),
+    ).rejects.toBe(fallbackError);
+    // Without this the dead ID stays in storage and every later start repeats
+    // the same rejected request.
+    expect(onUnavailableDevices).toHaveBeenCalledWith(["video"]);
   });
 
   it("keeps a device ID that still resolves while dropping the dead one", async () => {
@@ -95,13 +121,14 @@ describe("openInputMediaStream()", () => {
       makeDevice("audioinput", LIVE_AUDIO_ID),
     ]);
 
-    const opened = await openInputMediaStream(
+    await openInputMediaStream(
       { video: true, audio: true },
       STALE_VIDEO_ID,
       LIVE_AUDIO_ID,
+      onUnavailableDevices,
     );
 
-    expect(opened?.unavailableDeviceKinds).toEqual(["video"]);
+    expect(onUnavailableDevices).toHaveBeenCalledWith(["video"]);
     expect(getUserMedia).toHaveBeenLastCalledWith({
       video: true,
       audio: { deviceId: { exact: LIVE_AUDIO_ID } },
@@ -120,9 +147,11 @@ describe("openInputMediaStream()", () => {
         { video: { frameRate: { exact: 1000 } } },
         LIVE_VIDEO_ID,
         undefined,
+        onUnavailableDevices,
       ),
     ).rejects.toBe(error);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(onUnavailableDevices).not.toHaveBeenCalled();
   });
 
   it("ignores a stored ID for a kind the app disabled", async () => {
@@ -139,9 +168,11 @@ describe("openInputMediaStream()", () => {
         { video: true, audio: false },
         LIVE_VIDEO_ID,
         "stale-audio",
+        onUnavailableDevices,
       ),
     ).rejects.toBe(error);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(onUnavailableDevices).not.toHaveBeenCalled();
   });
 
   it("leaves a device ID that the app itself constrained", async () => {
@@ -154,9 +185,11 @@ describe("openInputMediaStream()", () => {
         { video: { deviceId: { exact: "app-chosen-video" } } },
         undefined,
         undefined,
+        onUnavailableDevices,
       ),
     ).rejects.toBe(error);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(onUnavailableDevices).not.toHaveBeenCalled();
   });
 
   it("does not retry errors other than OverconstrainedError", async () => {
@@ -164,7 +197,12 @@ describe("openInputMediaStream()", () => {
     getUserMedia.mockRejectedValue(error);
 
     await expect(
-      openInputMediaStream({ video: true }, STALE_VIDEO_ID, undefined),
+      openInputMediaStream(
+        { video: true },
+        STALE_VIDEO_ID,
+        undefined,
+        onUnavailableDevices,
+      ),
     ).rejects.toBe(error);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
     expect(enumerateDevices).not.toHaveBeenCalled();
@@ -176,13 +214,14 @@ describe("openInputMediaStream()", () => {
       .mockResolvedValueOnce(makeStream());
     enumerateDevices.mockRejectedValue(new Error("enumeration failed"));
 
-    const opened = await openInputMediaStream(
+    await openInputMediaStream(
       { video: true, audio: true },
       STALE_VIDEO_ID,
       LIVE_AUDIO_ID,
+      onUnavailableDevices,
     );
 
-    expect(opened?.unavailableDeviceKinds).toEqual(["video", "audio"]);
+    expect(onUnavailableDevices).toHaveBeenCalledWith(["video", "audio"]);
     expect(getUserMedia).toHaveBeenLastCalledWith({
       video: true,
       audio: true,
@@ -194,7 +233,12 @@ describe("openInputMediaStream()", () => {
     getUserMedia.mockRejectedValue(error);
 
     await expect(
-      openInputMediaStream({ video: true }, undefined, undefined),
+      openInputMediaStream(
+        { video: true },
+        undefined,
+        undefined,
+        onUnavailableDevices,
+      ),
     ).rejects.toBe(error);
     expect(getUserMedia).toHaveBeenCalledTimes(1);
   });

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
@@ -6,14 +6,6 @@ const MEDIA_DEVICE_KINDS: Record<InputDeviceKind, MediaDeviceKind> = {
   audio: "audioinput",
 };
 
-export interface OpenedInputMedia {
-  stream: MediaStream;
-  // Kinds whose requested device ID no longer resolves, so the stream was
-  // opened without it. The caller owns the stored selection and is the one
-  // that can replace the dead ID.
-  unavailableDeviceKinds: InputDeviceKind[];
-}
-
 function isOverconstrainedError(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -87,11 +79,16 @@ async function findUnavailableDeviceKinds(
 
 // Returns null when the compiled constraints ask for no media at all, in which
 // case there is nothing to capture and no permission to request.
+// `onUnavailableDevices` reports the kinds whose remembered ID names a device
+// that no longer exists. It fires before the retry rather than with the result,
+// because that verdict holds whether or not the retry goes on to succeed, and
+// the caller owning the stored selection needs it either way.
 export async function openInputMediaStream(
   mediaStreamConstraints: MediaStreamConstraints | undefined,
   videoDeviceId: MediaDeviceInfo["deviceId"] | undefined,
   audioDeviceId: MediaDeviceInfo["deviceId"] | undefined,
-): Promise<OpenedInputMedia | null> {
+  onUnavailableDevices: (unavailableDeviceKinds: InputDeviceKind[]) => void,
+): Promise<MediaStream | null> {
   const constraints = compileMediaConstraints(
     mediaStreamConstraints,
     videoDeviceId,
@@ -115,10 +112,7 @@ export async function openInputMediaStream(
   }
 
   try {
-    return {
-      stream: await navigator.mediaDevices.getUserMedia(constraints),
-      unavailableDeviceKinds: [],
-    };
+    return await navigator.mediaDevices.getUserMedia(constraints);
   } catch (error: unknown) {
     if (!isOverconstrainedError(error)) {
       throw error;
@@ -139,6 +133,8 @@ export async function openInputMediaStream(
       throw error;
     }
 
+    onUnavailableDevices(unavailableDeviceKinds);
+
     // Only the dead IDs are dropped, so an unplugged camera does not also
     // discard a microphone selection that is still valid.
     const fallbackConstraints = compileMediaConstraints(
@@ -152,9 +148,6 @@ export async function openInputMediaStream(
       "unavailable devices:",
       unavailableDeviceKinds,
     );
-    return {
-      stream: await navigator.mediaDevices.getUserMedia(fallbackConstraints),
-      unavailableDeviceKinds,
-    };
+    return await navigator.mediaDevices.getUserMedia(fallbackConstraints);
   }
 }

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
@@ -22,13 +22,45 @@ function isOverconstrainedError(error: unknown): boolean {
   );
 }
 
+function getAppliedDeviceId(
+  spec: MediaStreamConstraints["video"],
+): string | undefined {
+  if (typeof spec !== "object" || spec == null) {
+    return undefined;
+  }
+  const deviceId = spec.deviceId;
+  // `compileMediaConstraints` applies a remembered ID as an `exact` object.
+  // Anything else is the app's own constraint and not ours to drop.
+  if (
+    typeof deviceId === "object" &&
+    deviceId != null &&
+    !Array.isArray(deviceId) &&
+    typeof deviceId.exact === "string"
+  ) {
+    return deviceId.exact;
+  }
+  return undefined;
+}
+
+// Only the remembered IDs that reached the compiled constraints are candidates
+// for dropping: a kind the app disabled never received one, so that ID cannot
+// be what the browser rejected, and an ID the app constrained itself is not
+// ours to discard.
 async function findUnavailableDeviceKinds(
-  requestedDeviceIds: Record<InputDeviceKind, string | undefined>,
+  constraints: MediaStreamConstraints,
+  rememberedDeviceIds: Record<InputDeviceKind, string | undefined>,
 ): Promise<InputDeviceKind[]> {
-  const requestedKinds = (
-    Object.keys(requestedDeviceIds) as InputDeviceKind[]
-  ).filter((kind) => requestedDeviceIds[kind] != null);
-  if (requestedKinds.length === 0) {
+  const requestedDeviceIds = new Map<InputDeviceKind, string>();
+  (Object.keys(MEDIA_DEVICE_KINDS) as InputDeviceKind[]).forEach((kind) => {
+    const deviceId = rememberedDeviceIds[kind];
+    if (
+      deviceId != null &&
+      getAppliedDeviceId(constraints[kind]) === deviceId
+    ) {
+      requestedDeviceIds.set(kind, deviceId);
+    }
+  });
+  if (requestedDeviceIds.size === 0) {
     return [];
   }
 
@@ -38,17 +70,19 @@ async function findUnavailableDeviceKinds(
   } catch {
     // Without a device list there is no way to tell which ID went stale, so
     // treat every requested one as suspect rather than failing the start.
-    return requestedKinds;
+    return [...requestedDeviceIds.keys()];
   }
 
-  return requestedKinds.filter(
-    (kind) =>
-      !devices.some(
-        (device) =>
-          device.kind === MEDIA_DEVICE_KINDS[kind] &&
-          device.deviceId === requestedDeviceIds[kind],
-      ),
-  );
+  return [...requestedDeviceIds]
+    .filter(
+      ([kind, deviceId]) =>
+        !devices.some(
+          (device) =>
+            device.kind === MEDIA_DEVICE_KINDS[kind] &&
+            device.deviceId === deviceId,
+        ),
+    )
+    .map(([kind]) => kind);
 }
 
 // Returns null when the compiled constraints ask for no media at all, in which
@@ -94,14 +128,14 @@ export async function openInputMediaStream(
     // IDs when site data or the camera permission is reset, and the device
     // itself can be unplugged. Those IDs go in as `exact` constraints, so a
     // dead one rejects the whole capture instead of degrading.
-    const unavailableDeviceKinds = await findUnavailableDeviceKinds({
-      video: videoDeviceId,
-      audio: audioDeviceId,
-    });
+    const unavailableDeviceKinds = await findUnavailableDeviceKinds(
+      constraints,
+      { video: videoDeviceId, audio: audioDeviceId },
+    );
     if (unavailableDeviceKinds.length === 0) {
-      // Every requested device is present, so something else in the
-      // constraints is unsatisfiable and dropping the IDs would open the
-      // wrong device rather than fix anything.
+      // No remembered ID is at fault, so something else in the constraints is
+      // unsatisfiable and retrying would open the wrong device rather than fix
+      // anything.
       throw error;
     }
 

--- a/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/open-input-media-stream.ts
@@ -1,0 +1,126 @@
+import { compileMediaConstraints } from "../media-constraint";
+import type { InputDeviceKind } from "./switch-input-device";
+
+const MEDIA_DEVICE_KINDS: Record<InputDeviceKind, MediaDeviceKind> = {
+  video: "videoinput",
+  audio: "audioinput",
+};
+
+export interface OpenedInputMedia {
+  stream: MediaStream;
+  // Kinds whose requested device ID no longer resolves, so the stream was
+  // opened without it. The caller owns the stored selection and is the one
+  // that can replace the dead ID.
+  unavailableDeviceKinds: InputDeviceKind[];
+}
+
+function isOverconstrainedError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error != null &&
+    (error as { name?: unknown }).name === "OverconstrainedError"
+  );
+}
+
+async function findUnavailableDeviceKinds(
+  requestedDeviceIds: Record<InputDeviceKind, string | undefined>,
+): Promise<InputDeviceKind[]> {
+  const requestedKinds = (
+    Object.keys(requestedDeviceIds) as InputDeviceKind[]
+  ).filter((kind) => requestedDeviceIds[kind] != null);
+  if (requestedKinds.length === 0) {
+    return [];
+  }
+
+  let devices: MediaDeviceInfo[];
+  try {
+    devices = await navigator.mediaDevices.enumerateDevices();
+  } catch {
+    // Without a device list there is no way to tell which ID went stale, so
+    // treat every requested one as suspect rather than failing the start.
+    return requestedKinds;
+  }
+
+  return requestedKinds.filter(
+    (kind) =>
+      !devices.some(
+        (device) =>
+          device.kind === MEDIA_DEVICE_KINDS[kind] &&
+          device.deviceId === requestedDeviceIds[kind],
+      ),
+  );
+}
+
+// Returns null when the compiled constraints ask for no media at all, in which
+// case there is nothing to capture and no permission to request.
+export async function openInputMediaStream(
+  mediaStreamConstraints: MediaStreamConstraints | undefined,
+  videoDeviceId: MediaDeviceInfo["deviceId"] | undefined,
+  audioDeviceId: MediaDeviceInfo["deviceId"] | undefined,
+): Promise<OpenedInputMedia | null> {
+  const constraints = compileMediaConstraints(
+    mediaStreamConstraints,
+    videoDeviceId,
+    audioDeviceId,
+  );
+  console.debug("MediaStreamConstraints:", constraints);
+
+  if (!constraints.audio && !constraints.video) {
+    return null;
+  }
+
+  if (navigator.mediaDevices == null) {
+    // Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#privacy_and_security
+    // > A secure context is, in short, a page loaded using HTTPS or the file:/// URL scheme, or a page loaded from localhost.
+    throw new Error(
+      "navigator.mediaDevices is undefined. It seems the current document is not loaded securely.",
+    );
+  }
+  if (navigator.mediaDevices.getUserMedia == null) {
+    throw new Error("getUserMedia is not implemented in this browser");
+  }
+
+  try {
+    return {
+      stream: await navigator.mediaDevices.getUserMedia(constraints),
+      unavailableDeviceKinds: [],
+    };
+  } catch (error: unknown) {
+    if (!isOverconstrainedError(error)) {
+      throw error;
+    }
+
+    // A remembered device ID outlives the device it names: browsers reissue
+    // IDs when site data or the camera permission is reset, and the device
+    // itself can be unplugged. Those IDs go in as `exact` constraints, so a
+    // dead one rejects the whole capture instead of degrading.
+    const unavailableDeviceKinds = await findUnavailableDeviceKinds({
+      video: videoDeviceId,
+      audio: audioDeviceId,
+    });
+    if (unavailableDeviceKinds.length === 0) {
+      // Every requested device is present, so something else in the
+      // constraints is unsatisfiable and dropping the IDs would open the
+      // wrong device rather than fix anything.
+      throw error;
+    }
+
+    // Only the dead IDs are dropped, so an unplugged camera does not also
+    // discard a microphone selection that is still valid.
+    const fallbackConstraints = compileMediaConstraints(
+      mediaStreamConstraints,
+      unavailableDeviceKinds.includes("video") ? undefined : videoDeviceId,
+      unavailableDeviceKinds.includes("audio") ? undefined : audioDeviceId,
+    );
+    console.debug(
+      "Retrying with fallback MediaStreamConstraints:",
+      fallbackConstraints,
+      "unavailable devices:",
+      unavailableDeviceKinds,
+    );
+    return {
+      stream: await navigator.mediaDevices.getUserMedia(fallbackConstraints),
+      unavailableDeviceKinds,
+    };
+  }
+}


### PR DESCRIPTION
Selecting an input device persists its ID in `localStorage`, and that ID goes into `getUserMedia` as an `exact` constraint so the browser cannot quietly substitute a different device. A device ID does not stay valid forever, though: browsers reissue them when site data or the camera permission is reset, and the device itself can be unplugged. When the stored ID no longer resolves, the `exact` constraint rejects the whole capture with `OverconstrainedError` and the stream never starts, even for an app that asked for nothing more specific than `{"video": True}`.

Capture now retries when that happens. The capture path moves out of `useWebRtc` into `openInputMediaStream()`, which owns the retry and reports back which kinds it dropped. On `OverconstrainedError`, `enumerateDevices()` decides which of the remembered IDs are actually gone, and only those are dropped before the capture is retried once, so an unplugged camera does not also discard a microphone selection that is still valid. When the device list cannot be read at all, every remembered ID that reached the constraints is dropped rather than failing the start. An ID the app itself constrained is never dropped, and if no remembered ID is at fault the error is re-raised untouched, because then some other constraint is unsatisfiable and retrying would open the wrong device instead of fixing anything. The dead ID is replaced by the device that actually opened, or dropped when the retry reports none, so the next start does not repeat the failed attempt and the device picker stops pointing at an entry that no longer exists.

`pnpm test` in `streamlit_webrtc/frontend` runs the tests. The `WebRtcStreamer` cases assert the storage overwrite for a device reported as gone, with the ordinary browser-chosen-fallback case as a control so the assertion cannot pass vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream startup when previously selected audio or video devices are no longer available.
  * Automatically retries using available devices and updates saved selections accordingly.
  * Preserves valid device selections while removing unavailable ones.
  * Correctly clears saved selections when no replacement device can be opened.

* **Tests**
  * Added comprehensive coverage for device fallback, persistence, clearing behavior, and media access failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->