### PR TITLE
Extract media device enumeration into a `useMediaInputDevices()` hook

### DIFF
--- a/changelog.d/20260806_183000_t.yic.yt_media_input_devices_hook.md
+++ b/changelog.d/20260806_183000_t.yic.yt_media_input_devices_hook.md
@@ -1,0 +1,3 @@
+### Chore
+
+- The device picker's media-device enumeration moved into a reusable `useMediaInputDevices()` hook, which also stops the picker from crashing outside a secure context, where `navigator.mediaDevices` is undefined.

--- a/changelog.d/20260806_183000_t.yic.yt_media_input_devices_hook.md
+++ b/changelog.d/20260806_183000_t.yic.yt_media_input_devices_hook.md
@@ -1,3 +1,3 @@
 ### Chore
 
-- The device picker's media-device enumeration moved into a reusable `useMediaInputDevices()` hook, which also stops the picker from crashing outside a secure context, where `navigator.mediaDevices` is undefined.
+- The media device enumeration behind the device selection dialog moved into a reusable `useMediaInputDevices()` hook.

--- a/changelog.d/20260806_190500_t.yic.yt_device_select_insecure_context.md
+++ b/changelog.d/20260806_190500_t.yic.yt_device_select_insecure_context.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- The device selection dialog no longer crashes when the page is served outside a secure context, where `navigator.mediaDevices` is undefined.

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
@@ -63,7 +63,8 @@ describe("<DeviceSelect />", () => {
             makeDevice("first-video"),
             makeDevice("second-video"),
           ]),
-        ondevicechange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
       },
     });
 

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
@@ -94,24 +94,27 @@ describe("<DeviceSelect />", () => {
     expect(select.value).toBe("old-video");
   });
 
-  // The enumeration on mount runs before the permission prompt is answered.
-  // Resolving a selection from what it reports would hand the caller an ID that
-  // names no device, and the caller persists what it is given.
-  it("resolves nothing while the device list is still unlabelled", async () => {
+  // Permission is granted per kind, so the enumeration that runs before the
+  // prompt is answered can carry every microphone and no camera at all. The
+  // caller persists what it is told, and half an answer erases the other half.
+  it("resolves nothing until permission is granted", async () => {
     const onSelectionResolved = vi.fn();
     stubMediaDevices({
       getUserMedia: vi.fn().mockReturnValue(new Promise(() => undefined)),
-      enumerateDevices: vi
-        .fn()
-        .mockResolvedValue([makeMediaDevice("", "videoinput", "")]),
+      enumerateDevices: vi.fn().mockResolvedValue([
+        // The camera is known to exist and nothing more, the microphone was
+        // permitted on an earlier visit.
+        makeMediaDevice("", "videoinput", ""),
+        makeMediaDevice("old-audio", "audioinput"),
+      ]),
     });
 
     render(
       <DeviceSelect
         video
-        audio={false}
+        audio
         defaultVideoDeviceId="old-video"
-        defaultAudioDeviceId={undefined}
+        defaultAudioDeviceId="old-audio"
         onSelectionResolved={onSelectionResolved}
         onVideoSelect={vi.fn()}
         onAudioSelect={vi.fn()}
@@ -119,9 +122,7 @@ describe("<DeviceSelect />", () => {
     );
 
     await act(async () => undefined);
-    expect(onSelectionResolved).not.toHaveBeenCalledWith(
-      expect.objectContaining({ video: "" }),
-    );
+    expect(onSelectionResolved).not.toHaveBeenCalled();
   });
 
   it("returns to the requested device when it comes back", async () => {

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
@@ -125,6 +125,57 @@ describe("<DeviceSelect />", () => {
     expect(onSelectionResolved).not.toHaveBeenCalled();
   });
 
+  // The permission refresh can be superseded by a `devicechange` that granting
+  // permission itself sets off. Treating its resolution as "the list is ready"
+  // would report a selection built from the pre-permission list.
+  it("resolves nothing while the permission refresh is still outstanding", async () => {
+    const onSelectionResolved = vi.fn();
+    const pending: Array<(devices: MediaDeviceInfo[]) => void> = [];
+    const listeners: Array<() => void> = [];
+    stubMediaDevices({
+      getUserMedia: vi.fn().mockResolvedValue(RESOLVED_STREAM),
+      enumerateDevices: vi.fn(
+        () =>
+          new Promise<MediaDeviceInfo[]>((resolve) => pending.push(resolve)),
+      ),
+      addEventListener: vi.fn((_type: string, listener: EventListener) =>
+        listeners.push(listener as () => void),
+      ),
+    });
+
+    render(
+      <DeviceSelect
+        video
+        audio
+        defaultVideoDeviceId="old-video"
+        defaultAudioDeviceId="old-audio"
+        onSelectionResolved={onSelectionResolved}
+        onVideoSelect={vi.fn()}
+        onAudioSelect={vi.fn()}
+      />,
+    );
+
+    // The enumeration on mount lands first, carrying the microphone permitted
+    // on an earlier visit and nothing usable for the camera.
+    await act(async () =>
+      pending[0]?.([
+        makeMediaDevice("", "videoinput", ""),
+        makeMediaDevice("old-audio", "audioinput"),
+      ]),
+    );
+    await act(async () => listeners.forEach((listener) => listener()));
+    // The permission refresh settles after that newer enumeration started, so
+    // its result is dropped and the list is still the one from mount.
+    await act(async () =>
+      pending[1]?.([
+        makeMediaDevice("old-video", "videoinput"),
+        makeMediaDevice("old-audio", "audioinput"),
+      ]),
+    );
+
+    expect(onSelectionResolved).not.toHaveBeenCalled();
+  });
+
   it("returns to the requested device when it comes back", async () => {
     let attached = [makeDevice("old-video"), makeDevice("spare")];
     const listeners: Array<() => void> = [];

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.test.tsx
@@ -7,6 +7,10 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import DeviceSelect from "./DeviceSelect";
+import {
+  makeDevice as makeMediaDevice,
+  stubMediaDevices,
+} from "../media-devices-test-utils";
 
 vi.mock("streamlit-component-lib", () => ({
   Streamlit: { setFrameHeight: vi.fn() },
@@ -17,14 +21,14 @@ vi.mock("./VideoPreview", () => ({
 }));
 
 function makeDevice(deviceId: string): MediaDeviceInfo {
-  return {
-    deviceId,
-    groupId: "video-group",
-    kind: "videoinput",
-    label: deviceId,
-    toJSON: () => ({}),
-  };
+  return makeMediaDevice(deviceId, "videoinput", deviceId);
 }
+
+const RESOLVED_STREAM = {
+  getTracks: () => [],
+  getVideoTracks: () => [],
+  getAudioTracks: () => [],
+};
 
 afterEach(() => {
   cleanup();
@@ -49,23 +53,15 @@ describe("<DeviceSelect />", () => {
             rejectSecondSelection = reject;
           }),
       );
-    vi.stubGlobal("navigator", {
-      mediaDevices: {
-        getUserMedia: vi.fn().mockResolvedValue({
-          getTracks: () => [],
-          getVideoTracks: () => [],
-          getAudioTracks: () => [],
-        }),
-        enumerateDevices: vi
-          .fn()
-          .mockResolvedValue([
-            makeDevice("old-video"),
-            makeDevice("first-video"),
-            makeDevice("second-video"),
-          ]),
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-      },
+    stubMediaDevices({
+      getUserMedia: vi.fn().mockResolvedValue(RESOLVED_STREAM),
+      enumerateDevices: vi
+        .fn()
+        .mockResolvedValue([
+          makeDevice("old-video"),
+          makeDevice("first-video"),
+          makeDevice("second-video"),
+        ]),
     });
 
     render(
@@ -95,6 +91,77 @@ describe("<DeviceSelect />", () => {
     await act(async () =>
       rejectSecondSelection?.(new Error("Second switch failed")),
     );
+    expect(select.value).toBe("old-video");
+  });
+
+  // The enumeration on mount runs before the permission prompt is answered.
+  // Resolving a selection from what it reports would hand the caller an ID that
+  // names no device, and the caller persists what it is given.
+  it("resolves nothing while the device list is still unlabelled", async () => {
+    const onSelectionResolved = vi.fn();
+    stubMediaDevices({
+      getUserMedia: vi.fn().mockReturnValue(new Promise(() => undefined)),
+      enumerateDevices: vi
+        .fn()
+        .mockResolvedValue([makeMediaDevice("", "videoinput", "")]),
+    });
+
+    render(
+      <DeviceSelect
+        video
+        audio={false}
+        defaultVideoDeviceId="old-video"
+        defaultAudioDeviceId={undefined}
+        onSelectionResolved={onSelectionResolved}
+        onVideoSelect={vi.fn()}
+        onAudioSelect={vi.fn()}
+      />,
+    );
+
+    await act(async () => undefined);
+    expect(onSelectionResolved).not.toHaveBeenCalledWith(
+      expect.objectContaining({ video: "" }),
+    );
+  });
+
+  it("returns to the requested device when it comes back", async () => {
+    let attached = [makeDevice("old-video"), makeDevice("spare")];
+    const listeners: Array<() => void> = [];
+    stubMediaDevices({
+      getUserMedia: vi.fn().mockResolvedValue(RESOLVED_STREAM),
+      enumerateDevices: vi.fn(() => Promise.resolve(attached)),
+      addEventListener: vi.fn((_type: string, listener: EventListener) =>
+        listeners.push(listener as () => void),
+      ),
+    });
+    const emitDeviceChange = async (devices: MediaDeviceInfo[]) => {
+      attached = devices;
+      await act(async () => listeners.forEach((listener) => listener()));
+    };
+
+    render(
+      <DeviceSelect
+        video
+        audio={false}
+        defaultVideoDeviceId="old-video"
+        defaultAudioDeviceId={undefined}
+        onSelectionResolved={vi.fn()}
+        onVideoSelect={vi.fn()}
+        onAudioSelect={vi.fn()}
+      />,
+    );
+
+    const select = (await screen.findByLabelText(
+      "Video Input",
+    )) as HTMLSelectElement;
+    expect(select.value).toBe("old-video");
+
+    // Unplugged: the only device left is the one the picker falls back to.
+    await emitDeviceChange([makeDevice("spare")]);
+    expect(select.value).toBe("spare");
+
+    // Plugged back in: the request was never withdrawn, so it applies again.
+    await emitDeviceChange([makeDevice("old-video"), makeDevice("spare")]);
     expect(select.value).toBe("old-video");
   });
 });

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -33,6 +33,9 @@ function ensureValidSelection(
   return undefined;
 }
 
+// `MEDIA_API_UNAVAILABLE` covers the half of the media API this component needs
+// that the device list does not: a browser exposing `enumerateDevices` but no
+// `getUserMedia` leaves nothing to wait for, and there is no permission to ask.
 type PermissionState = "WAITING" | "ALLOWED" | "MEDIA_API_UNAVAILABLE" | Error;
 
 export interface DeviceSelectProps {

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -161,6 +161,13 @@ function DeviceSelect(props: DeviceSelectProps) {
   );
 
   useEffect(() => {
+    // Permission is granted per kind, so before the prompt is answered a
+    // browser can name every microphone while withholding every camera. The
+    // caller stores what it is told, and an absent kind reads there as "forget
+    // the device you had" rather than "nothing to say about it yet".
+    if (permissionState !== "ALLOWED") {
+      return;
+    }
     const videoInput = useVideo
       ? videoInputs.find((d) => d.deviceId === selectedVideoInputDeviceId)
       : null;
@@ -172,6 +179,7 @@ function DeviceSelect(props: DeviceSelectProps) {
       audio: audioInput?.deviceId,
     });
   }, [
+    permissionState,
     useVideo,
     useAudio,
     onSelectionResolved,

--- a/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
+++ b/streamlit_webrtc/frontend/src/DeviceSelect/DeviceSelect.tsx
@@ -1,13 +1,6 @@
 import { Streamlit } from "streamlit-component-lib";
-import {
-  useReducer,
-  Reducer,
-  useCallback,
-  useState,
-  useEffect,
-  useRef,
-} from "react";
-import NativeSelect, { NativeSelectProps } from "@mui/material/NativeSelect";
+import { useCallback, useState, useEffect, useRef } from "react";
+import NativeSelect from "@mui/material/NativeSelect";
 import Alert from "@mui/material/Alert";
 import Stack from "@mui/material/Stack";
 import InputLabel from "@mui/material/InputLabel";
@@ -23,6 +16,8 @@ import VoidVideoPreview from "./components/VoidVideoPreview";
 import Defer from "./components/Defer";
 import VideoPreview from "./VideoPreview";
 import { stopAllTracks } from "./utils";
+import { useMediaInputDevices } from "../use-media-input-devices";
+import type { InputDeviceKind } from "../webrtc";
 
 function ensureValidSelection(
   devices: MediaDeviceInfo[],
@@ -38,85 +33,7 @@ function ensureValidSelection(
   return undefined;
 }
 
-interface DeviceSelectionState {
-  unavailable: boolean;
-  videoInputs: MediaDeviceInfo[];
-  audioInputs: MediaDeviceInfo[];
-  audioOutputs: MediaDeviceInfo[];
-  // TODO: Add selectedAudioOutputDeviceId
-  selectedVideoInputDeviceId: MediaDeviceInfo["deviceId"] | undefined;
-  selectedAudioInputDeviceId: MediaDeviceInfo["deviceId"] | undefined;
-}
-interface DeviceSelectionActionBase {
-  type: string;
-}
-interface DeviceSelectionSetUnavailableAction extends DeviceSelectionActionBase {
-  type: "SET_UNAVAILABLE";
-}
-interface DeviceSelectionUpdateDevicesAction extends DeviceSelectionActionBase {
-  type: "UPDATE_DEVICES";
-  devices: MediaDeviceInfo[];
-}
-interface DeviceSelectionUpdateSelectedDeviceIdAction extends DeviceSelectionActionBase {
-  type: "UPDATE_SELECTED_DEVICE_ID";
-  payload: {
-    selectedVideoInputDeviceId?: MediaDeviceInfo["deviceId"] | undefined;
-    selectedAudioInputDeviceId?: MediaDeviceInfo["deviceId"] | undefined;
-  };
-}
-type DeviceSelectionAction =
-  | DeviceSelectionSetUnavailableAction
-  | DeviceSelectionUpdateDevicesAction
-  | DeviceSelectionUpdateSelectedDeviceIdAction;
-const deviceSelectionReducer: Reducer<
-  DeviceSelectionState,
-  DeviceSelectionAction
-> = (state, action) => {
-  switch (action.type) {
-    case "SET_UNAVAILABLE": {
-      return {
-        unavailable: true,
-        videoInputs: [],
-        audioInputs: [],
-        audioOutputs: [],
-        selectedVideoInputDeviceId: undefined,
-        selectedAudioInputDeviceId: undefined,
-      };
-    }
-    case "UPDATE_DEVICES": {
-      const devices = action.devices;
-      const videoInputs = devices.filter((d) => d.kind === "videoinput");
-      const audioInputs = devices.filter((d) => d.kind === "audioinput");
-      const audioOutputs = devices.filter((d) => d.kind === "audiooutput");
-
-      const selectedVideoInputDeviceId = ensureValidSelection(
-        videoInputs,
-        state.selectedVideoInputDeviceId,
-      );
-      const selectedAudioInputDeviceId = ensureValidSelection(
-        audioInputs,
-        state.selectedAudioInputDeviceId,
-      );
-
-      return {
-        ...state,
-        videoInputs,
-        audioInputs,
-        audioOutputs,
-        selectedVideoInputDeviceId,
-        selectedAudioInputDeviceId,
-      };
-    }
-    case "UPDATE_SELECTED_DEVICE_ID": {
-      return {
-        ...state,
-        ...action.payload,
-      };
-    }
-  }
-};
-
-type PermissionState = "WAITING" | "ALLOWED" | Error;
+type PermissionState = "WAITING" | "ALLOWED" | "MEDIA_API_UNAVAILABLE" | Error;
 
 export interface DeviceSelectProps {
   video: boolean;
@@ -148,38 +65,26 @@ function DeviceSelect(props: DeviceSelectProps) {
   const [permissionState, setPermissionState] =
     useState<PermissionState>("WAITING");
 
-  const [
-    {
-      unavailable,
-      videoInputs,
-      selectedVideoInputDeviceId,
-      audioInputs,
-      selectedAudioInputDeviceId,
-    },
-    deviceSelectionDispatch,
-  ] = useReducer(deviceSelectionReducer, {
-    unavailable: false,
-    videoInputs: [],
-    audioInputs: [],
-    audioOutputs: [],
-    selectedVideoInputDeviceId: defaultVideoDeviceId,
-    selectedAudioInputDeviceId: defaultAudioDeviceId,
+  const {
+    devices: { video: videoInputs, audio: audioInputs },
+    unavailable,
+    refresh: refreshDeviceList,
+  } = useMediaInputDevices();
+
+  const [requestedDeviceIds, setRequestedDeviceIds] = useState<
+    Partial<Record<InputDeviceKind, MediaDeviceInfo["deviceId"]>>
+  >({
+    video: defaultVideoDeviceId,
+    audio: defaultAudioDeviceId,
   });
-
-  // Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/ondevicechange#example
-  const updateDeviceList = useCallback(() => {
-    if (typeof navigator?.mediaDevices?.enumerateDevices !== "function") {
-      deviceSelectionDispatch({ type: "SET_UNAVAILABLE" });
-      return;
-    }
-
-    return navigator.mediaDevices.enumerateDevices().then((devices) => {
-      deviceSelectionDispatch({
-        type: "UPDATE_DEVICES",
-        devices,
-      });
-    });
-  }, []);
+  const selectedVideoInputDeviceId = ensureValidSelection(
+    videoInputs,
+    requestedDeviceIds.video,
+  );
+  const selectedAudioInputDeviceId = ensureValidSelection(
+    audioInputs,
+    requestedDeviceIds.audio,
+  );
 
   // These values are passed to inside the useEffect below via a ref
   // because they are used there only for UX improvement
@@ -196,7 +101,7 @@ function DeviceSelect(props: DeviceSelectProps) {
   // Call `getUserMedia()` to ask the user for the permission.
   useEffect(() => {
     if (typeof navigator?.mediaDevices?.getUserMedia !== "function") {
-      deviceSelectionDispatch({ type: "SET_UNAVAILABLE" });
+      setPermissionState("MEDIA_API_UNAVAILABLE");
       return;
     }
 
@@ -218,79 +123,38 @@ function DeviceSelect(props: DeviceSelectProps) {
       .then(async (stream) => {
         stopAllTracks(stream);
 
-        await updateDeviceList();
+        // Device labels are only populated once the permission is granted, so
+        // the list this component renders comes from an enumeration made here
+        // rather than the one on mount.
+        await refreshDeviceList();
 
         setPermissionState("ALLOWED");
       })
       .catch((err) => {
         setPermissionState(err);
       });
-  }, [useVideo, useAudio, updateDeviceList]);
+  }, [useVideo, useAudio, refreshDeviceList]);
 
-  // Set up the ondevicechange event handler
-  useEffect(() => {
-    const handleDeviceChange = () => updateDeviceList();
-    navigator.mediaDevices.ondevicechange = handleDeviceChange;
-
-    return () => {
-      if (navigator.mediaDevices.ondevicechange === handleDeviceChange) {
-        navigator.mediaDevices.ondevicechange = null;
-      }
-    };
-  }, [updateDeviceList]);
-
-  const handleVideoInputChange = useCallback<
-    NonNullable<NativeSelectProps["onChange"]>
-  >(
-    (e) => {
-      const video = e.target.value;
-      const requestId = ++selectionRequestIdsRef.current.video;
-      deviceSelectionDispatch({
-        type: "UPDATE_SELECTED_DEVICE_ID",
-        payload: { selectedVideoInputDeviceId: video },
-      });
+  const handleInputChange = useCallback(
+    (kind: InputDeviceKind, deviceId: MediaDeviceInfo["deviceId"]) => {
+      const requestId = ++selectionRequestIdsRef.current[kind];
+      setRequestedDeviceIds((prev) => ({ ...prev, [kind]: deviceId }));
+      const onSelect = kind === "video" ? onVideoSelect : onAudioSelect;
       void Promise.resolve()
-        .then(() => onVideoSelect(video))
+        .then(() => onSelect(deviceId))
         .catch(() => {
-          if (selectionRequestIdsRef.current.video !== requestId) {
+          // Only the latest request may roll the selection back; an older one
+          // failing after it would drop a choice the user has already made.
+          if (selectionRequestIdsRef.current[kind] !== requestId) {
             return;
           }
-          deviceSelectionDispatch({
-            type: "UPDATE_SELECTED_DEVICE_ID",
-            payload: {
-              selectedVideoInputDeviceId: defaultDeviceIdsRef.current.video,
-            },
-          });
+          setRequestedDeviceIds((prev) => ({
+            ...prev,
+            [kind]: defaultDeviceIdsRef.current[kind],
+          }));
         });
     },
-    [onVideoSelect],
-  );
-
-  const handleAudioInputChange = useCallback<
-    NonNullable<NativeSelectProps["onChange"]>
-  >(
-    (e) => {
-      const audio = e.target.value;
-      const requestId = ++selectionRequestIdsRef.current.audio;
-      deviceSelectionDispatch({
-        type: "UPDATE_SELECTED_DEVICE_ID",
-        payload: { selectedAudioInputDeviceId: audio },
-      });
-      void Promise.resolve()
-        .then(() => onAudioSelect(audio))
-        .catch(() => {
-          if (selectionRequestIdsRef.current.audio !== requestId) {
-            return;
-          }
-          deviceSelectionDispatch({
-            type: "UPDATE_SELECTED_DEVICE_ID",
-            payload: {
-              selectedAudioInputDeviceId: defaultDeviceIdsRef.current.audio,
-            },
-          });
-        });
-    },
-    [onAudioSelect],
+    [onVideoSelect, onAudioSelect],
   );
 
   useEffect(() => {
@@ -318,7 +182,7 @@ function DeviceSelect(props: DeviceSelectProps) {
     setTimeout(() => Streamlit.setFrameHeight());
   });
 
-  if (unavailable) {
+  if (unavailable || permissionState === "MEDIA_API_UNAVAILABLE") {
     return <MediaApiNotAvailableMessage />;
   }
 
@@ -374,7 +238,7 @@ function DeviceSelect(props: DeviceSelectProps) {
                 id: "device-select-video-input",
               }}
               value={selectedVideoInputDeviceId}
-              onChange={handleVideoInputChange}
+              onChange={(e) => handleInputChange("video", e.target.value)}
             >
               {videoInputs.map((device) => (
                 <option key={device.deviceId} value={device.deviceId}>
@@ -395,7 +259,7 @@ function DeviceSelect(props: DeviceSelectProps) {
                 id: "device-select-audio-input",
               }}
               value={selectedAudioInputDeviceId}
-              onChange={handleAudioInputChange}
+              onChange={(e) => handleInputChange("audio", e.target.value)}
             >
               {audioInputs.map((device) => (
                 <option key={device.deviceId} value={device.deviceId}>

--- a/streamlit_webrtc/frontend/src/media-devices-test-utils.ts
+++ b/streamlit_webrtc/frontend/src/media-devices-test-utils.ts
@@ -1,0 +1,28 @@
+import { vi } from "vitest";
+
+export function makeDevice(
+  deviceId: string,
+  kind: MediaDeviceKind,
+  label = `${deviceId} label`,
+): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: `${deviceId}-group`,
+    kind,
+    label,
+    toJSON: () => ({}),
+  };
+}
+
+// `navigator.mediaDevices` does not exist in jsdom, so tests that reach it
+// bring their own. The listener pair is stubbed for every caller because the
+// device list is watched wherever it is read.
+export function stubMediaDevices(mediaDevices: Partial<MediaDevices>) {
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      ...mediaDevices,
+    },
+  });
+}

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
@@ -111,6 +111,40 @@ describe("useMediaInputDevices()", () => {
     ]);
   });
 
+  it("does not settle an awaited refresh on a result it discarded", async () => {
+    const pending: Array<(devices: MediaDeviceInfo[]) => void> = [];
+    stubMediaDevices({
+      enumerateDevices: vi.fn(
+        () =>
+          new Promise<MediaDeviceInfo[]>((resolve) => pending.push(resolve)),
+      ),
+    });
+
+    const { result } = renderHook(() => useMediaInputDevices());
+
+    let awaitedRefreshSettled = false;
+    await act(async () => {
+      void result.current.refresh().then(() => {
+        awaitedRefreshSettled = true;
+      });
+    });
+    // A `devicechange` between the refresh and its result supersedes it.
+    await act(async () => {
+      void result.current.refresh();
+    });
+
+    await act(async () =>
+      pending[1]?.([makeDevice("discarded", "videoinput")]),
+    );
+    expect(awaitedRefreshSettled).toBe(false);
+
+    await act(async () => pending[2]?.([makeDevice("newest", "videoinput")]));
+    expect(awaitedRefreshSettled).toBe(true);
+    expect(result.current.devices.video.map((d) => d.deviceId)).toEqual([
+      "newest",
+    ]);
+  });
+
   // `navigator.mediaDevices` is undefined outside a secure context, so every
   // access has to tolerate it being missing rather than throwing on mount.
   it("reports the media API as unavailable when devices cannot be enumerated", () => {

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useMediaInputDevices } from "./use-media-input-devices";
+
+function makeDevice(deviceId: string, kind: MediaDeviceKind): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: `${deviceId}-group`,
+    kind,
+    label: deviceId,
+    toJSON: () => ({}),
+  };
+}
+
+function stubMediaDevices(mediaDevices: Partial<MediaDevices>) {
+  vi.stubGlobal("navigator", { mediaDevices });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useMediaInputDevices()", () => {
+  it("splits the enumerated devices by kind", async () => {
+    stubMediaDevices({
+      enumerateDevices: vi
+        .fn()
+        .mockResolvedValue([
+          makeDevice("camera", "videoinput"),
+          makeDevice("microphone", "audioinput"),
+          makeDevice("speaker", "audiooutput"),
+        ]),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useMediaInputDevices());
+
+    await waitFor(() =>
+      expect(result.current.devices.video.map((d) => d.deviceId)).toEqual([
+        "camera",
+      ]),
+    );
+    expect(result.current.devices.audio.map((d) => d.deviceId)).toEqual([
+      "microphone",
+    ]);
+    expect(result.current.unavailable).toBe(false);
+  });
+
+  it("re-enumerates when the device list changes", async () => {
+    const listeners: Array<() => void> = [];
+    const enumerateDevices = vi
+      .fn()
+      .mockResolvedValueOnce([makeDevice("camera", "videoinput")])
+      .mockResolvedValueOnce([
+        makeDevice("camera", "videoinput"),
+        makeDevice("usb-camera", "videoinput"),
+      ]);
+    stubMediaDevices({
+      enumerateDevices,
+      addEventListener: vi.fn((_type: string, listener: EventListener) =>
+        listeners.push(listener as () => void),
+      ),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useMediaInputDevices());
+    await waitFor(() => expect(result.current.devices.video).toHaveLength(1));
+
+    await act(async () => listeners.forEach((listener) => listener()));
+
+    expect(result.current.devices.video.map((d) => d.deviceId)).toEqual([
+      "camera",
+      "usb-camera",
+    ]);
+  });
+
+  it("keeps the latest result when an earlier enumeration resolves late", async () => {
+    let resolveOnMount: ((devices: MediaDeviceInfo[]) => void) | undefined;
+    let resolveRefresh: ((devices: MediaDeviceInfo[]) => void) | undefined;
+    stubMediaDevices({
+      enumerateDevices: vi
+        .fn()
+        .mockImplementationOnce(
+          () => new Promise((resolve) => (resolveOnMount = resolve)),
+        )
+        .mockImplementationOnce(
+          () => new Promise((resolve) => (resolveRefresh = resolve)),
+        ),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useMediaInputDevices());
+    // The enumeration on mount runs before the permission prompt is answered,
+    // so its labels are empty. The refresh a consumer makes once permission is
+    // granted is the authoritative one, whichever settles first.
+    await act(async () => {
+      void result.current.refresh();
+    });
+
+    await act(async () =>
+      resolveRefresh?.([makeDevice("labeled", "videoinput")]),
+    );
+    await act(async () => resolveOnMount?.([makeDevice("", "videoinput")]));
+
+    expect(result.current.devices.video.map((d) => d.deviceId)).toEqual([
+      "labeled",
+    ]);
+  });
+
+  // `navigator.mediaDevices` is undefined outside a secure context, so every
+  // access has to tolerate it being missing rather than throwing on mount.
+  it("reports the media API as unavailable when devices cannot be enumerated", () => {
+    vi.stubGlobal("navigator", {});
+
+    const { result } = renderHook(() => useMediaInputDevices());
+
+    expect(result.current.unavailable).toBe(true);
+    expect(result.current.devices.video).toEqual([]);
+    expect(result.current.devices.audio).toEqual([]);
+  });
+});

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.test.ts
@@ -1,20 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useMediaInputDevices } from "./use-media-input-devices";
-
-function makeDevice(deviceId: string, kind: MediaDeviceKind): MediaDeviceInfo {
-  return {
-    deviceId,
-    groupId: `${deviceId}-group`,
-    kind,
-    label: deviceId,
-    toJSON: () => ({}),
-  };
-}
-
-function stubMediaDevices(mediaDevices: Partial<MediaDevices>) {
-  vi.stubGlobal("navigator", { mediaDevices });
-}
+import { makeDevice, stubMediaDevices } from "./media-devices-test-utils";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -30,8 +17,6 @@ describe("useMediaInputDevices()", () => {
           makeDevice("microphone", "audioinput"),
           makeDevice("speaker", "audiooutput"),
         ]),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
     });
 
     const { result } = renderHook(() => useMediaInputDevices());
@@ -45,6 +30,24 @@ describe("useMediaInputDevices()", () => {
       "microphone",
     ]);
     expect(result.current.unavailable).toBe(false);
+  });
+
+  // Reporting these as devices would let a caller resolve a selection to the
+  // empty ID and store it over the one the user actually chose.
+  it("ignores the placeholder entries reported before permission is granted", async () => {
+    stubMediaDevices({
+      enumerateDevices: vi
+        .fn()
+        .mockResolvedValue([
+          makeDevice("", "videoinput", ""),
+          makeDevice("", "audioinput", ""),
+        ]),
+    });
+
+    const { result } = renderHook(() => useMediaInputDevices());
+
+    await act(async () => undefined);
+    expect(result.current.devices).toEqual({ video: [], audio: [] });
   });
 
   it("re-enumerates when the device list changes", async () => {
@@ -61,7 +64,6 @@ describe("useMediaInputDevices()", () => {
       addEventListener: vi.fn((_type: string, listener: EventListener) =>
         listeners.push(listener as () => void),
       ),
-      removeEventListener: vi.fn(),
     });
 
     const { result } = renderHook(() => useMediaInputDevices());
@@ -87,8 +89,6 @@ describe("useMediaInputDevices()", () => {
         .mockImplementationOnce(
           () => new Promise((resolve) => (resolveRefresh = resolve)),
         ),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
     });
 
     const { result } = renderHook(() => useMediaInputDevices());
@@ -102,7 +102,9 @@ describe("useMediaInputDevices()", () => {
     await act(async () =>
       resolveRefresh?.([makeDevice("labeled", "videoinput")]),
     );
-    await act(async () => resolveOnMount?.([makeDevice("", "videoinput")]));
+    await act(async () =>
+      resolveOnMount?.([makeDevice("stale", "videoinput")]),
+    );
 
     expect(result.current.devices.video.map((d) => d.deviceId)).toEqual([
       "labeled",

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface MediaInputDevices {
+  video: MediaDeviceInfo[];
+  audio: MediaDeviceInfo[];
+}
+
+const NO_DEVICES: MediaInputDevices = { video: [], audio: [] };
+
+// Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/ondevicechange#example
+export function useMediaInputDevices() {
+  const [devices, setDevices] = useState<MediaInputDevices>(NO_DEVICES);
+
+  const unavailable =
+    typeof navigator?.mediaDevices?.enumerateDevices !== "function";
+
+  // Device labels stay empty until the user grants media permission, so a
+  // caller holding the permission prompt refreshes once it is granted. That
+  // result must survive an earlier enumeration resolving late.
+  const latestRequestIdRef = useRef(0);
+  const refresh = useCallback(async (): Promise<void> => {
+    if (typeof navigator?.mediaDevices?.enumerateDevices !== "function") {
+      return;
+    }
+    const requestId = ++latestRequestIdRef.current;
+    const allDevices = await navigator.mediaDevices.enumerateDevices();
+    if (latestRequestIdRef.current !== requestId) {
+      return;
+    }
+    setDevices({
+      video: allDevices.filter((device) => device.kind === "videoinput"),
+      audio: allDevices.filter((device) => device.kind === "audioinput"),
+    });
+  }, []);
+
+  useEffect(() => {
+    const enumerate = () => {
+      refresh().catch(() => undefined);
+    };
+
+    enumerate();
+
+    // `addEventListener` rather than the `ondevicechange` property so several
+    // components can watch the device list at once.
+    navigator?.mediaDevices?.addEventListener("devicechange", enumerate);
+    return () => {
+      navigator?.mediaDevices?.removeEventListener("devicechange", enumerate);
+    };
+  }, [refresh]);
+
+  return { devices, unavailable, refresh };
+}

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.ts
@@ -18,24 +18,34 @@ export function useMediaInputDevices() {
   // caller holding the permission prompt refreshes once it is granted. That
   // result must survive an earlier enumeration resolving late.
   const latestRequestIdRef = useRef(0);
-  const refresh = useCallback(async (): Promise<void> => {
+  const latestRefreshRef = useRef<Promise<void>>();
+  const refresh = useCallback((): Promise<void> => {
     if (typeof navigator?.mediaDevices?.enumerateDevices !== "function") {
-      return;
+      return Promise.resolve();
     }
     const requestId = ++latestRequestIdRef.current;
-    const allDevices = await navigator.mediaDevices.enumerateDevices();
-    if (latestRequestIdRef.current !== requestId) {
-      return;
-    }
-    // Before permission is granted browsers report one placeholder entry per
-    // kind, carrying no ID and no label. Those name no device that can be
-    // opened, selected or remembered, so they are not devices as far as
-    // callers are concerned.
-    const devices = allDevices.filter((device) => device.deviceId !== "");
-    setDevices({
-      video: devices.filter((device) => device.kind === "videoinput"),
-      audio: devices.filter((device) => device.kind === "audioinput"),
-    });
+    const refreshing = navigator.mediaDevices
+      .enumerateDevices()
+      .then((allDevices) => {
+        if (latestRequestIdRef.current !== requestId) {
+          // This result is discarded, so resolving here would tell a caller
+          // the list is current while it still holds an older one. Hand over
+          // the enumeration that superseded this one instead: awaiting a
+          // refresh has to end with a list at least as new as it asked for.
+          return latestRefreshRef.current;
+        }
+        // Before permission is granted browsers report one placeholder entry
+        // per kind, carrying no ID and no label. Those name no device that can
+        // be opened, selected or remembered, so they are not devices as far as
+        // callers are concerned.
+        const devices = allDevices.filter((device) => device.deviceId !== "");
+        setDevices({
+          video: devices.filter((device) => device.kind === "videoinput"),
+          audio: devices.filter((device) => device.kind === "audioinput"),
+        });
+      });
+    latestRefreshRef.current = refreshing;
+    return refreshing;
   }, []);
 
   useEffect(() => {

--- a/streamlit_webrtc/frontend/src/use-media-input-devices.ts
+++ b/streamlit_webrtc/frontend/src/use-media-input-devices.ts
@@ -27,15 +27,24 @@ export function useMediaInputDevices() {
     if (latestRequestIdRef.current !== requestId) {
       return;
     }
+    // Before permission is granted browsers report one placeholder entry per
+    // kind, carrying no ID and no label. Those name no device that can be
+    // opened, selected or remembered, so they are not devices as far as
+    // callers are concerned.
+    const devices = allDevices.filter((device) => device.deviceId !== "");
     setDevices({
-      video: allDevices.filter((device) => device.kind === "videoinput"),
-      audio: allDevices.filter((device) => device.kind === "audioinput"),
+      video: devices.filter((device) => device.kind === "videoinput"),
+      audio: devices.filter((device) => device.kind === "audioinput"),
     });
   }, []);
 
   useEffect(() => {
     const enumerate = () => {
-      refresh().catch(() => undefined);
+      // Nothing awaits these two, unlike the caller-driven `refresh()`, so a
+      // failure would otherwise disappear.
+      refresh().catch((error) =>
+        console.error("Failed to enumerate media devices", error),
+      );
     };
 
     enumerate();


### PR DESCRIPTION
The device picker owned the only live list of media input devices: it enumerated them, split them by kind and resubscribed on `devicechange`, all inside a reducer that also reconciled the picker's own selection. Nothing else could list devices without repeating that.

The enumeration, the `devicechange` subscription and the media-API availability check move into `useMediaInputDevices()`. What is left in `DeviceSelect` is the selection, which no longer needs a reducer: the effective device is derived during render from the requested ID and the current list, so its two duplicated change handlers collapse into one keyed by device kind.

The hook enumerates on mount, which the picker did not do before, so `DeviceSelect` now enumerates twice per open: once on mount, and once after its permission prompt resolves, because device labels stay empty until then. Two things fall out of that. Entries carrying no device ID, which is all a browser reports before permission is granted, are dropped, since the empty ID is not nullish and would otherwise reach storage and overwrite the remembered device. And when two enumerations overlap, the one requested last wins rather than the one that settles last.

Two other behavior notes: the picker no longer throws on mount outside a secure context, where `navigator.mediaDevices` is undefined; and with the selection derived rather than stored, a device that disappears and comes back is selected again when it is still the requested one, where before the picker stayed on the fallback it had moved to.

`pnpm test` in `streamlit_webrtc/frontend` runs the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved media input device detection and organization for audio and video selections.
  - Device lists now refresh automatically when hardware changes or permissions are granted.
  - Invalid or unavailable device entries are filtered from selection dialogs.

- **Bug Fixes**
  - Prevented device selection dialogs from crashing when media APIs are unavailable outside secure contexts.
  - Restored the previously requested device after temporary unplugging and reconnection.
  - Improved handling of stale device updates and failed selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->