### PR TITLE
Add an input device dropdown next to the camera and microphone toggles

### DIFF
--- a/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
+++ b/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
@@ -1,3 +1,3 @@
 ### Added
 
-- The camera and microphone buttons shown while streaming now each carry a dropdown for picking another input device, so switching cameras or microphones mid-stream no longer means opening the device selector. A dropdown appears when the browser reports more than one device of that kind and identifies which one is currently live, and its label can be customized through the new `select_camera` and `select_microphone` entries of `translations`.
+- The camera and microphone buttons shown while streaming now each carry a dropdown for picking another input device, so switching cameras or microphones mid-stream no longer means opening the device selector. A dropdown appears whenever the browser reports another device of that kind to switch to, and its label can be customized through the new `select_camera` and `select_microphone` entries of `translations`.

--- a/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
+++ b/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
@@ -1,0 +1,3 @@
+### Added
+
+- The camera and microphone buttons shown while streaming now each carry a dropdown for picking another input device, so switching cameras or microphones mid-stream no longer means opening the device selector. A dropdown appears only when the browser reports more than one device of that kind, and its label can be customized through the new `select_camera` and `select_microphone` entries of `translations`.

--- a/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
+++ b/changelog.d/20260806_185500_t.yic.yt_inline_device_dropdowns.md
@@ -1,3 +1,3 @@
 ### Added
 
-- The camera and microphone buttons shown while streaming now each carry a dropdown for picking another input device, so switching cameras or microphones mid-stream no longer means opening the device selector. A dropdown appears only when the browser reports more than one device of that kind, and its label can be customized through the new `select_camera` and `select_microphone` entries of `translations`.
+- The camera and microphone buttons shown while streaming now each carry a dropdown for picking another input device, so switching cameras or microphones mid-stream no longer means opening the device selector. A dropdown appears when the browser reports more than one device of that kind and identifies which one is currently live, and its label can be customized through the new `select_camera` and `select_microphone` entries of `translations`.

--- a/pages/13_ui_texts_customization.py
+++ b/pages/13_ui_texts_customization.py
@@ -14,5 +14,7 @@ webrtc_streamer(
         "turn_camera_off": "カメラをオフにする",
         "mute_microphone": "マイクをミュートする",
         "unmute_microphone": "マイクのミュートを解除する",
+        "select_camera": "カメラを選択する",
+        "select_microphone": "マイクを選択する",
     },
 )

--- a/streamlit_webrtc/config.py
+++ b/streamlit_webrtc/config.py
@@ -179,6 +179,8 @@ class Translations(TypedDict, total=False):
     turn_camera_off: str
     mute_microphone: str
     unmute_microphone: str
+    select_camera: str
+    select_microphone: str
 
 
 DEFAULT_MEDIA_STREAM_CONSTRAINTS = MediaStreamConstraints(audio=True, video=True)

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -263,6 +263,9 @@ describe("<InputMediaControls />", () => {
     })) as HTMLSelectElement;
     fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
     expect(cameraSelect.value).toBe("cam-2");
+    // The displayed device is set before the switch is asked for, so without
+    // this the switch could never be made and the rest would still hold.
+    expect(onSelectDevice).toHaveBeenCalledWith("video", "cam-2");
 
     // The switch was asked for on a stream that is no longer here, so the
     // device it is waiting on describes nothing about the one that replaced it.

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -14,12 +14,30 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+interface FakeTrack {
+  enabled: boolean;
+}
+
+function makeTrack({
+  deviceId,
+  readyState = "live",
+}: {
+  deviceId?: string;
+  readyState?: MediaStreamTrackState;
+} = {}): FakeTrack {
+  return {
+    enabled: true,
+    readyState,
+    getSettings: () => ({ deviceId }),
+  } as unknown as FakeTrack;
+}
+
 function makeStream({
   videoTrack,
   audioTrack,
 }: {
-  videoTrack?: Pick<MediaStreamTrack, "enabled">;
-  audioTrack?: Pick<MediaStreamTrack, "enabled">;
+  videoTrack?: FakeTrack;
+  audioTrack?: FakeTrack;
 }) {
   return {
     getVideoTracks: () => (videoTrack ? [videoTrack] : []),
@@ -40,14 +58,13 @@ const TWO_OF_EACH = [
 
 describe("<InputMediaControls />", () => {
   it("toggles camera and microphone tracks", () => {
-    const videoTrack = { enabled: true };
-    const audioTrack = { enabled: true };
+    const videoTrack = makeTrack({ deviceId: "cam-1" });
+    const audioTrack = makeTrack({ deviceId: "mic-1" });
     const stream = makeStream({ videoTrack, audioTrack });
 
     render(
       <InputMediaControls
         stream={stream}
-        selectedDeviceIds={{}}
         onSelectDevice={vi.fn().mockResolvedValue(undefined)}
       />,
     );
@@ -80,12 +97,11 @@ describe("<InputMediaControls />", () => {
   });
 
   it("renders only controls for existing tracks", () => {
-    const stream = makeStream({ audioTrack: { enabled: true } });
+    const stream = makeStream({ audioTrack: makeTrack({ deviceId: "mic-1" }) });
 
     render(
       <InputMediaControls
         stream={stream}
-        selectedDeviceIds={{}}
         onSelectDevice={vi.fn().mockResolvedValue(undefined)}
       />,
     );
@@ -103,10 +119,9 @@ describe("<InputMediaControls />", () => {
     render(
       <InputMediaControls
         stream={makeStream({
-          videoTrack: { enabled: true },
-          audioTrack: { enabled: true },
+          videoTrack: makeTrack({ deviceId: "cam-1" }),
+          audioTrack: makeTrack({ deviceId: "mic-1" }),
         })}
-        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
         onSelectDevice={onSelectDevice}
       />,
     );
@@ -134,10 +149,9 @@ describe("<InputMediaControls />", () => {
     render(
       <InputMediaControls
         stream={makeStream({
-          videoTrack: { enabled: true },
-          audioTrack: { enabled: true },
+          videoTrack: makeTrack({ deviceId: "cam-1" }),
+          audioTrack: makeTrack({ deviceId: "mic-1" }),
         })}
-        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
         onSelectDevice={vi.fn().mockResolvedValue(undefined)}
       />,
     );
@@ -149,15 +163,16 @@ describe("<InputMediaControls />", () => {
   });
 
   it("still offers a picker once the live device is unplugged", async () => {
-    // Only the survivor is enumerated, while the selection still names the
-    // camera that went away.
+    // Only the survivor is enumerated, and the track of the camera that went
+    // away has ended.
     stubDevices([makeDevice("cam-2", "videoinput")]);
     const onSelectDevice = vi.fn().mockResolvedValue(undefined);
 
     render(
       <InputMediaControls
-        stream={makeStream({ videoTrack: { enabled: true } })}
-        selectedDeviceIds={{ video: "cam-1" }}
+        stream={makeStream({
+          videoTrack: makeTrack({ deviceId: "cam-1", readyState: "ended" }),
+        })}
         onSelectDevice={onSelectDevice}
       />,
     );
@@ -169,6 +184,31 @@ describe("<InputMediaControls />", () => {
 
     fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
     expect(onSelectDevice).toHaveBeenCalledWith("video", "cam-2");
+  });
+
+  it("can pick the same camera again once it is plugged back in", async () => {
+    // The camera is back under the ID it had before, but the track that ended
+    // when it was unplugged stays ended, so nothing is feeding the connection
+    // and that ID has to remain selectable.
+    stubDevices([makeDevice("cam-1", "videoinput")]);
+    const onSelectDevice = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InputMediaControls
+        stream={makeStream({
+          videoTrack: makeTrack({ deviceId: "cam-1", readyState: "ended" }),
+        })}
+        onSelectDevice={onSelectDevice}
+      />,
+    );
+
+    const cameraSelect = (await screen.findByRole("combobox", {
+      name: "Select camera",
+    })) as HTMLSelectElement;
+    expect(cameraSelect.value).toBe("");
+
+    fireEvent.change(cameraSelect, { target: { value: "cam-1" } });
+    expect(onSelectDevice).toHaveBeenCalledWith("video", "cam-1");
   });
 
   it("holds the pending device until the switch settles, then reverts if it fails", async () => {
@@ -183,8 +223,7 @@ describe("<InputMediaControls />", () => {
 
     render(
       <InputMediaControls
-        stream={makeStream({ videoTrack: { enabled: true } })}
-        selectedDeviceIds={{ video: "cam-1" }}
+        stream={makeStream({ videoTrack: makeTrack({ deviceId: "cam-1" }) })}
         onSelectDevice={onSelectDevice}
       />,
     );
@@ -193,8 +232,8 @@ describe("<InputMediaControls />", () => {
       name: "Select camera",
     })) as HTMLSelectElement;
     fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
-    // The parent confirms the new device only once the switch succeeds, so the
-    // picker holds the pending one meanwhile instead of snapping back.
+    // The switch has not reached a track yet, so the picker holds the pending
+    // device rather than snapping back to the one still live.
     expect(cameraSelect.value).toBe("cam-2");
 
     await act(async () => rejectSwitch?.(new Error("Device is busy")));
@@ -204,12 +243,10 @@ describe("<InputMediaControls />", () => {
 
   it("holds the picker inert while its kind is turned off", async () => {
     stubDevices(TWO_OF_EACH);
-    const videoTrack = { enabled: true };
 
     render(
       <InputMediaControls
-        stream={makeStream({ videoTrack })}
-        selectedDeviceIds={{ video: "cam-1" }}
+        stream={makeStream({ videoTrack: makeTrack({ deviceId: "cam-1" }) })}
         onSelectDevice={vi.fn().mockResolvedValue(undefined)}
       />,
     );

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -148,6 +148,29 @@ describe("<InputMediaControls />", () => {
     ).toBeNull();
   });
 
+  it("still offers a picker once the live device is unplugged", async () => {
+    // Only the survivor is enumerated, while the selection still names the
+    // camera that went away.
+    stubDevices([makeDevice("cam-2", "videoinput")]);
+    const onSelectDevice = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InputMediaControls
+        stream={makeStream({ videoTrack: { enabled: true } })}
+        selectedDeviceIds={{ video: "cam-1" }}
+        onSelectDevice={onSelectDevice}
+      />,
+    );
+
+    const cameraSelect = (await screen.findByRole("combobox", {
+      name: "Select camera",
+    })) as HTMLSelectElement;
+    expect(cameraSelect.value).toBe("");
+
+    fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
+    expect(onSelectDevice).toHaveBeenCalledWith("video", "cam-2");
+  });
+
   it("holds the pending device until the switch settles, then reverts if it fails", async () => {
     stubDevices(TWO_OF_EACH);
     let rejectSwitch: ((error: Error) => void) | undefined;

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
 } from "@testing-library/react";
 import InputMediaControls from "./InputMediaControls";
+import { makeDevice, stubMediaDevices } from "./media-devices-test-utils";
 
 afterEach(() => {
   cleanup();
@@ -26,24 +27,8 @@ function makeStream({
   } as unknown as MediaStream;
 }
 
-function makeDevice(deviceId: string, kind: MediaDeviceKind): MediaDeviceInfo {
-  return {
-    deviceId,
-    groupId: `${deviceId}-group`,
-    kind,
-    label: `${deviceId} label`,
-    toJSON: () => ({}),
-  };
-}
-
 function stubDevices(devices: MediaDeviceInfo[]) {
-  vi.stubGlobal("navigator", {
-    mediaDevices: {
-      enumerateDevices: vi.fn().mockResolvedValue(devices),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    },
-  });
+  stubMediaDevices({ enumerateDevices: vi.fn().mockResolvedValue(devices) });
 }
 
 const TWO_OF_EACH = [
@@ -59,7 +44,13 @@ describe("<InputMediaControls />", () => {
     const audioTrack = { enabled: true };
     const stream = makeStream({ videoTrack, audioTrack });
 
-    render(<InputMediaControls stream={stream} />);
+    render(
+      <InputMediaControls
+        stream={stream}
+        selectedDeviceIds={{}}
+        onSelectDevice={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
     const cameraButton = screen.getByRole("button", {
       name: "Turn camera off",
@@ -91,7 +82,13 @@ describe("<InputMediaControls />", () => {
   it("renders only controls for existing tracks", () => {
     const stream = makeStream({ audioTrack: { enabled: true } });
 
-    render(<InputMediaControls stream={stream} />);
+    render(
+      <InputMediaControls
+        stream={stream}
+        selectedDeviceIds={{}}
+        onSelectDevice={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
     expect(screen.queryByRole("button", { name: /camera/i })).toBeNull();
     expect(
@@ -182,20 +179,26 @@ describe("<InputMediaControls />", () => {
     expect(cameraSelect.value).toBe("cam-1");
   });
 
-  it("offers no picker when the stream cannot switch devices", async () => {
+  it("holds the picker inert while its kind is turned off", async () => {
     stubDevices(TWO_OF_EACH);
+    const videoTrack = { enabled: true };
 
     render(
       <InputMediaControls
-        stream={makeStream({
-          videoTrack: { enabled: true },
-          audioTrack: { enabled: true },
-        })}
-        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
+        stream={makeStream({ videoTrack })}
+        selectedDeviceIds={{ video: "cam-1" }}
+        onSelectDevice={vi.fn().mockResolvedValue(undefined)}
       />,
     );
 
-    await screen.findByRole("button", { name: "Turn camera off" });
-    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
+    const cameraSelect = (await screen.findByRole("combobox", {
+      name: "Select camera",
+    })) as HTMLSelectElement;
+    expect(cameraSelect.disabled).toBe(false);
+
+    // Switching opens the chosen device, so offering it under a camera the
+    // user has turned off would light the indicator of a camera shown as off.
+    fireEvent.click(screen.getByRole("button", { name: "Turn camera off" }));
+    expect(cameraSelect.disabled).toBe(true);
   });
 });

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -241,6 +241,42 @@ describe("<InputMediaControls />", () => {
     expect(cameraSelect.value).toBe("cam-1");
   });
 
+  it("drops a pending device when the stream it was asked for is replaced", async () => {
+    stubDevices(TWO_OF_EACH);
+    let finishSwitch: (() => void) | undefined;
+    const onSelectDevice = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSwitch = resolve;
+        }),
+    );
+    const streamer = (stream: MediaStream) => (
+      <InputMediaControls stream={stream} onSelectDevice={onSelectDevice} />
+    );
+
+    const { rerender } = render(
+      streamer(makeStream({ videoTrack: makeTrack({ deviceId: "cam-1" }) })),
+    );
+
+    const cameraSelect = (await screen.findByRole("combobox", {
+      name: "Select camera",
+    })) as HTMLSelectElement;
+    fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
+    expect(cameraSelect.value).toBe("cam-2");
+
+    // The switch was asked for on a stream that is no longer here, so the
+    // device it is waiting on describes nothing about the one that replaced it.
+    await act(async () =>
+      rerender(
+        streamer(makeStream({ videoTrack: makeTrack({ deviceId: "cam-1" }) })),
+      ),
+    );
+    expect(cameraSelect.value).toBe("cam-1");
+
+    await act(async () => finishSwitch?.());
+    expect(cameraSelect.value).toBe("cam-1");
+  });
+
   it("holds the picker inert while its kind is turned off", async () => {
     stubDevices(TWO_OF_EACH);
 

--- a/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.test.tsx
@@ -1,9 +1,16 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import InputMediaControls from "./InputMediaControls";
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 function makeStream({
@@ -18,6 +25,33 @@ function makeStream({
     getAudioTracks: () => (audioTrack ? [audioTrack] : []),
   } as unknown as MediaStream;
 }
+
+function makeDevice(deviceId: string, kind: MediaDeviceKind): MediaDeviceInfo {
+  return {
+    deviceId,
+    groupId: `${deviceId}-group`,
+    kind,
+    label: `${deviceId} label`,
+    toJSON: () => ({}),
+  };
+}
+
+function stubDevices(devices: MediaDeviceInfo[]) {
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      enumerateDevices: vi.fn().mockResolvedValue(devices),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+  });
+}
+
+const TWO_OF_EACH = [
+  makeDevice("cam-1", "videoinput"),
+  makeDevice("cam-2", "videoinput"),
+  makeDevice("mic-1", "audioinput"),
+  makeDevice("mic-2", "audioinput"),
+];
 
 describe("<InputMediaControls />", () => {
   it("toggles camera and microphone tracks", () => {
@@ -63,5 +97,105 @@ describe("<InputMediaControls />", () => {
     expect(
       screen.getByRole("button", { name: "Mute microphone" }),
     ).not.toBeNull();
+  });
+
+  it("switches the input device from the control row", async () => {
+    stubDevices(TWO_OF_EACH);
+    const onSelectDevice = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <InputMediaControls
+        stream={makeStream({
+          videoTrack: { enabled: true },
+          audioTrack: { enabled: true },
+        })}
+        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
+        onSelectDevice={onSelectDevice}
+      />,
+    );
+
+    const cameraSelect = await screen.findByRole("combobox", {
+      name: "Select camera",
+    });
+    fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
+    expect(onSelectDevice).toHaveBeenCalledWith("video", "cam-2");
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Select microphone" }),
+      { target: { value: "mic-2" } },
+    );
+    expect(onSelectDevice).toHaveBeenCalledWith("audio", "mic-2");
+  });
+
+  it("offers no picker for a kind with nothing to switch to", async () => {
+    stubDevices([
+      makeDevice("cam-1", "videoinput"),
+      makeDevice("mic-1", "audioinput"),
+      makeDevice("mic-2", "audioinput"),
+    ]);
+
+    render(
+      <InputMediaControls
+        stream={makeStream({
+          videoTrack: { enabled: true },
+          audioTrack: { enabled: true },
+        })}
+        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
+        onSelectDevice={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await screen.findByRole("combobox", { name: "Select microphone" });
+    expect(
+      screen.queryByRole("combobox", { name: "Select camera" }),
+    ).toBeNull();
+  });
+
+  it("holds the pending device until the switch settles, then reverts if it fails", async () => {
+    stubDevices(TWO_OF_EACH);
+    let rejectSwitch: ((error: Error) => void) | undefined;
+    const onSelectDevice = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSwitch = reject;
+        }),
+    );
+
+    render(
+      <InputMediaControls
+        stream={makeStream({ videoTrack: { enabled: true } })}
+        selectedDeviceIds={{ video: "cam-1" }}
+        onSelectDevice={onSelectDevice}
+      />,
+    );
+
+    const cameraSelect = (await screen.findByRole("combobox", {
+      name: "Select camera",
+    })) as HTMLSelectElement;
+    fireEvent.change(cameraSelect, { target: { value: "cam-2" } });
+    // The parent confirms the new device only once the switch succeeds, so the
+    // picker holds the pending one meanwhile instead of snapping back.
+    expect(cameraSelect.value).toBe("cam-2");
+
+    await act(async () => rejectSwitch?.(new Error("Device is busy")));
+
+    expect(cameraSelect.value).toBe("cam-1");
+  });
+
+  it("offers no picker when the stream cannot switch devices", async () => {
+    stubDevices(TWO_OF_EACH);
+
+    render(
+      <InputMediaControls
+        stream={makeStream({
+          videoTrack: { enabled: true },
+          audioTrack: { enabled: true },
+        })}
+        selectedDeviceIds={{ video: "cam-1", audio: "mic-1" }}
+      />,
+    );
+
+    await screen.findByRole("button", { name: "Turn camera off" });
+    expect(screen.queryAllByRole("combobox")).toHaveLength(0);
   });
 });

--- a/streamlit_webrtc/frontend/src/InputMediaControls.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.tsx
@@ -181,12 +181,22 @@ function InputMediaControls({
     video: areTracksEnabled(stream, "video"),
     audio: areTracksEnabled(stream, "audio"),
   }));
+  // A switch only reaches the track it is opening when it succeeds, so until
+  // then the picker shows the device being waited on rather than the one still
+  // live.
+  const [pendingDeviceIds, setPendingDeviceIds] = useState<DeviceIds>({});
+  const selectionRequestIdsRef = useRef({ video: 0, audio: 0 });
 
   useEffect(() => {
     setEnabled({
       video: areTracksEnabled(stream, "video"),
       audio: areTracksEnabled(stream, "audio"),
     });
+    // A switch in flight was asked for on the stream being replaced, so the
+    // device it is waiting on describes nothing here. Its own completion is
+    // already ignored once a later request exists, so dropping the display
+    // value is all this needs.
+    setPendingDeviceIds({});
   }, [stream]);
 
   const labels = {
@@ -210,11 +220,6 @@ function InputMediaControls({
   // from here happens with media permission granted, which is what makes the
   // browser hand over device labels at all.
   const { devices } = useMediaInputDevices();
-  // The parent only confirms a device once the switch to it succeeds, so until
-  // then the picker shows the pending one rather than snapping back to the
-  // device that is still live.
-  const [pendingDeviceIds, setPendingDeviceIds] = useState<DeviceIds>({});
-  const selectionRequestIdsRef = useRef({ video: 0, audio: 0 });
   const selectDevice = (
     kind: InputDeviceKind,
     deviceId: MediaDeviceInfo["deviceId"],

--- a/streamlit_webrtc/frontend/src/InputMediaControls.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
@@ -18,8 +18,8 @@ type DeviceIds = Partial<Record<InputDeviceKind, MediaDeviceInfo["deviceId"]>>;
 interface InputMediaControlsProps {
   stream: MediaStream;
   disabled?: boolean;
-  selectedDeviceIds?: DeviceIds;
-  onSelectDevice?: (
+  selectedDeviceIds: DeviceIds;
+  onSelectDevice: (
     kind: InputDeviceKind,
     deviceId: MediaDeviceInfo["deviceId"],
   ) => Promise<void>;
@@ -64,6 +64,9 @@ const DeviceSelectOverlay = styled("select")({
   border: "none",
   appearance: "none",
   opacity: 0,
+  // Native controls do not inherit the page font, and iOS Safari zooms the
+  // page when a focused one is under 16px.
+  fontSize: 16,
   cursor: "pointer",
   "&:disabled": {
     cursor: "default",
@@ -184,24 +187,24 @@ function InputMediaControls({
   // then the picker shows the pending one rather than snapping back to the
   // device that is still live.
   const [pendingDeviceIds, setPendingDeviceIds] = useState<DeviceIds>({});
+  const selectionRequestIdsRef = useRef({ video: 0, audio: 0 });
   const selectDevice = (
     kind: InputDeviceKind,
     deviceId: MediaDeviceInfo["deviceId"],
   ) => {
-    if (onSelectDevice == null) {
-      return;
-    }
+    const requestId = ++selectionRequestIdsRef.current[kind];
     setPendingDeviceIds((prev) => ({ ...prev, [kind]: deviceId }));
-    const settle = () =>
+    const settle = () => {
+      // A later pick is already in flight and owns the displayed value.
+      if (selectionRequestIdsRef.current[kind] !== requestId) {
+        return;
+      }
       setPendingDeviceIds((prev) => {
-        // A later pick is already in flight and owns the displayed value.
-        if (prev[kind] !== deviceId) {
-          return prev;
-        }
         const next = { ...prev };
         delete next[kind];
         return next;
       });
+    };
     onSelectDevice(kind, deviceId).then(settle, settle);
   };
 
@@ -215,7 +218,7 @@ function InputMediaControls({
       disableLabel: labels.turnCameraOff,
       selectLabel: labels.selectCamera,
       devices: devices.video,
-      selectedDeviceId: pendingDeviceIds.video ?? selectedDeviceIds?.video,
+      selectedDeviceId: pendingDeviceIds.video ?? selectedDeviceIds.video,
     },
     {
       kind: "audio" as const,
@@ -226,7 +229,7 @@ function InputMediaControls({
       disableLabel: labels.muteMicrophone,
       selectLabel: labels.selectMicrophone,
       devices: devices.audio,
-      selectedDeviceId: pendingDeviceIds.audio ?? selectedDeviceIds?.audio,
+      selectedDeviceId: pendingDeviceIds.audio ?? selectedDeviceIds.audio,
     },
   ].filter((control) => control.present);
 
@@ -256,16 +259,17 @@ function InputMediaControls({
                 {isEnabled ? control.onIcon : control.offIcon}
               </IconButton>
             </Tooltip>
-            {onSelectDevice != null && (
-              <InputDeviceSelect
-                kind={control.kind}
-                label={control.selectLabel}
-                devices={control.devices}
-                selectedDeviceId={control.selectedDeviceId}
-                disabled={disabled}
-                onSelect={(deviceId) => selectDevice(control.kind, deviceId)}
-              />
-            )}
+            <InputDeviceSelect
+              kind={control.kind}
+              label={control.selectLabel}
+              devices={control.devices}
+              selectedDeviceId={control.selectedDeviceId}
+              // Switching opens the device, which lights its indicator. Doing
+              // that under a control the user has just turned off would say
+              // the opposite of what the screen says.
+              disabled={disabled || !isEnabled}
+              onSelect={(deviceId) => selectDevice(control.kind, deviceId)}
+            />
           </Box>
         );
       })}

--- a/streamlit_webrtc/frontend/src/InputMediaControls.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.tsx
@@ -1,32 +1,42 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
+import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
+import { styled } from "@mui/material/styles";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
 import VideocamIcon from "@mui/icons-material/Videocam";
 import VideocamOffIcon from "@mui/icons-material/VideocamOff";
 import MicIcon from "@mui/icons-material/Mic";
 import MicOffIcon from "@mui/icons-material/MicOff";
 import { useTranslation } from "./translation/useTranslation";
+import { useMediaInputDevices } from "./use-media-input-devices";
+import type { InputDeviceKind } from "./webrtc";
 
-type TrackKind = "video" | "audio";
+type DeviceIds = Partial<Record<InputDeviceKind, MediaDeviceInfo["deviceId"]>>;
 
 interface InputMediaControlsProps {
   stream: MediaStream;
   disabled?: boolean;
+  selectedDeviceIds?: DeviceIds;
+  onSelectDevice?: (
+    kind: InputDeviceKind,
+    deviceId: MediaDeviceInfo["deviceId"],
+  ) => Promise<void>;
 }
 
-function getTracks(stream: MediaStream, kind: TrackKind) {
+function getTracks(stream: MediaStream, kind: InputDeviceKind) {
   return kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
 }
 
-function areTracksEnabled(stream: MediaStream, kind: TrackKind) {
+function areTracksEnabled(stream: MediaStream, kind: InputDeviceKind) {
   const tracks = getTracks(stream, kind);
   return tracks.length > 0 && tracks.every((track) => track.enabled);
 }
 
 function setTracksEnabled(
   stream: MediaStream,
-  kind: TrackKind,
+  kind: InputDeviceKind,
   enabled: boolean,
 ) {
   getTracks(stream, kind).forEach((track) => {
@@ -34,22 +44,119 @@ function setTracksEnabled(
   });
 }
 
+// Device labels are only populated once media permission is granted, which it
+// is whenever these controls are on screen, so this is a safety net.
+function fallbackDeviceLabel(kind: InputDeviceKind, index: number) {
+  return `${kind === "video" ? "Camera" : "Microphone"} ${index + 1}`;
+}
+
+// The picker is a transparent native `<select>` covering the arrow icon.
+// Streamlit pins this iframe's height to its content, so a dropdown drawn in
+// the document would be clipped by the frame, while a native one is drawn by
+// the browser outside it (and opens as a native picker on mobile).
+const DeviceSelectOverlay = styled("select")({
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+  margin: 0,
+  padding: 0,
+  border: "none",
+  appearance: "none",
+  opacity: 0,
+  cursor: "pointer",
+  "&:disabled": {
+    cursor: "default",
+  },
+});
+
+interface InputDeviceSelectProps {
+  kind: InputDeviceKind;
+  label: string;
+  devices: MediaDeviceInfo[];
+  selectedDeviceId: MediaDeviceInfo["deviceId"] | undefined;
+  disabled: boolean;
+  onSelect: (deviceId: MediaDeviceInfo["deviceId"]) => void;
+}
+function InputDeviceSelect({
+  kind,
+  label,
+  devices,
+  selectedDeviceId,
+  disabled,
+  onSelect,
+}: InputDeviceSelectProps) {
+  // Without a second device there is nothing to pick, and without knowing which
+  // device is live the picker would misreport the current one.
+  const currentDevice = devices.find(
+    (device) => device.deviceId === selectedDeviceId,
+  );
+  if (devices.length < 2 || currentDevice == null) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={currentDevice.label || label}>
+      <Box
+        sx={{
+          position: "relative",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          // WCAG 2.2 SC 2.5.8 sets the minimum pointer target at 24 by 24.
+          width: 24,
+          height: 30,
+          borderRadius: 1,
+          // The same palette entries `IconButton` uses, so the arrow and the
+          // toggle it sits against read as one control.
+          color: disabled ? "action.disabled" : "action.active",
+          "&:focus-within": {
+            outline: "2px solid",
+            outlineColor: "primary.main",
+          },
+          "@media (hover: hover)": {
+            "&:hover": {
+              backgroundColor: disabled ? undefined : "action.hover",
+            },
+          },
+        }}
+      >
+        <ArrowDropDownIcon fontSize="small" />
+        <DeviceSelectOverlay
+          aria-label={label}
+          value={currentDevice.deviceId}
+          disabled={disabled}
+          onChange={(e) => onSelect(e.target.value)}
+        >
+          {devices.map((device, index) => (
+            <option key={device.deviceId} value={device.deviceId}>
+              {device.label || fallbackDeviceLabel(kind, index)}
+            </option>
+          ))}
+        </DeviceSelectOverlay>
+      </Box>
+    </Tooltip>
+  );
+}
+
 function InputMediaControls({
   disabled = false,
   stream,
+  selectedDeviceIds,
+  onSelectDevice,
 }: InputMediaControlsProps) {
   const hasVideo = stream.getVideoTracks().length > 0;
   const hasAudio = stream.getAudioTracks().length > 0;
-  const [videoEnabled, setVideoEnabled] = useState(() =>
-    areTracksEnabled(stream, "video"),
-  );
-  const [audioEnabled, setAudioEnabled] = useState(() =>
-    areTracksEnabled(stream, "audio"),
-  );
+  const [enabled, setEnabled] = useState(() => ({
+    video: areTracksEnabled(stream, "video"),
+    audio: areTracksEnabled(stream, "audio"),
+  }));
 
   useEffect(() => {
-    setVideoEnabled(areTracksEnabled(stream, "video"));
-    setAudioEnabled(areTracksEnabled(stream, "audio"));
+    setEnabled({
+      video: areTracksEnabled(stream, "video"),
+      audio: areTracksEnabled(stream, "audio"),
+    });
   }, [stream]);
 
   const labels = {
@@ -58,85 +165,110 @@ function InputMediaControls({
     muteMicrophone: useTranslation("mute_microphone") || "Mute microphone",
     unmuteMicrophone:
       useTranslation("unmute_microphone") || "Unmute microphone",
+    selectCamera: useTranslation("select_camera") || "Select camera",
+    selectMicrophone:
+      useTranslation("select_microphone") || "Select microphone",
   };
 
-  const toggleVideo = useCallback(() => {
-    const nextEnabled = !videoEnabled;
-    setTracksEnabled(stream, "video", nextEnabled);
-    setVideoEnabled(nextEnabled);
-  }, [stream, videoEnabled]);
+  const toggle = (kind: InputDeviceKind) => {
+    const nextEnabled = !enabled[kind];
+    setTracksEnabled(stream, kind, nextEnabled);
+    setEnabled((prev) => ({ ...prev, [kind]: nextEnabled }));
+  };
 
-  const toggleAudio = useCallback(() => {
-    const nextEnabled = !audioEnabled;
-    setTracksEnabled(stream, "audio", nextEnabled);
-    setAudioEnabled(nextEnabled);
-  }, [stream, audioEnabled]);
+  // These controls only exist while the input stream is live, so enumerating
+  // from here happens with media permission granted, which is what makes the
+  // browser hand over device labels at all.
+  const { devices } = useMediaInputDevices();
+  // The parent only confirms a device once the switch to it succeeds, so until
+  // then the picker shows the pending one rather than snapping back to the
+  // device that is still live.
+  const [pendingDeviceIds, setPendingDeviceIds] = useState<DeviceIds>({});
+  const selectDevice = (
+    kind: InputDeviceKind,
+    deviceId: MediaDeviceInfo["deviceId"],
+  ) => {
+    if (onSelectDevice == null) {
+      return;
+    }
+    setPendingDeviceIds((prev) => ({ ...prev, [kind]: deviceId }));
+    const settle = () =>
+      setPendingDeviceIds((prev) => {
+        // A later pick is already in flight and owns the displayed value.
+        if (prev[kind] !== deviceId) {
+          return prev;
+        }
+        const next = { ...prev };
+        delete next[kind];
+        return next;
+      });
+    onSelectDevice(kind, deviceId).then(settle, settle);
+  };
 
-  const controls = useMemo(
-    () => [
-      hasVideo && (
-        <Tooltip
-          key="video"
-          title={videoEnabled ? labels.turnCameraOff : labels.turnCameraOn}
-        >
-          <IconButton
-            aria-label={
-              videoEnabled ? labels.turnCameraOff : labels.turnCameraOn
-            }
-            aria-pressed={!videoEnabled}
-            color={videoEnabled ? "default" : "error"}
-            disabled={disabled}
-            onClick={toggleVideo}
-            size="small"
-            type="button"
-          >
-            {videoEnabled ? <VideocamIcon /> : <VideocamOffIcon />}
-          </IconButton>
-        </Tooltip>
-      ),
-      hasAudio && (
-        <Tooltip
-          key="audio"
-          title={audioEnabled ? labels.muteMicrophone : labels.unmuteMicrophone}
-        >
-          <IconButton
-            aria-label={
-              audioEnabled ? labels.muteMicrophone : labels.unmuteMicrophone
-            }
-            aria-pressed={!audioEnabled}
-            color={audioEnabled ? "default" : "error"}
-            disabled={disabled}
-            onClick={toggleAudio}
-            size="small"
-            type="button"
-          >
-            {audioEnabled ? <MicIcon /> : <MicOffIcon />}
-          </IconButton>
-        </Tooltip>
-      ),
-    ],
-    [
-      audioEnabled,
-      disabled,
-      hasAudio,
-      hasVideo,
-      labels.muteMicrophone,
-      labels.turnCameraOff,
-      labels.turnCameraOn,
-      labels.unmuteMicrophone,
-      toggleAudio,
-      toggleVideo,
-      videoEnabled,
-    ],
-  ).filter(Boolean);
+  const controls = [
+    {
+      kind: "video" as const,
+      present: hasVideo,
+      onIcon: <VideocamIcon />,
+      offIcon: <VideocamOffIcon />,
+      enableLabel: labels.turnCameraOn,
+      disableLabel: labels.turnCameraOff,
+      selectLabel: labels.selectCamera,
+      devices: devices.video,
+      selectedDeviceId: pendingDeviceIds.video ?? selectedDeviceIds?.video,
+    },
+    {
+      kind: "audio" as const,
+      present: hasAudio,
+      onIcon: <MicIcon />,
+      offIcon: <MicOffIcon />,
+      enableLabel: labels.unmuteMicrophone,
+      disableLabel: labels.muteMicrophone,
+      selectLabel: labels.selectMicrophone,
+      devices: devices.audio,
+      selectedDeviceId: pendingDeviceIds.audio ?? selectedDeviceIds?.audio,
+    },
+  ].filter((control) => control.present);
 
   if (controls.length === 0) {
     return null;
   }
 
   return (
-    <Stack direction="row" spacing={0.5}>
-      {controls}
+    <Stack direction="row" spacing={1}>
+      {controls.map((control) => {
+        const isEnabled = enabled[control.kind];
+        const toggleLabel = isEnabled
+          ? control.disableLabel
+          : control.enableLabel;
+        return (
+          <Box key={control.kind} display="inline-flex" alignItems="center">
+            <Tooltip title={toggleLabel}>
+              <IconButton
+                aria-label={toggleLabel}
+                aria-pressed={!isEnabled}
+                color={isEnabled ? "default" : "error"}
+                disabled={disabled}
+                onClick={() => toggle(control.kind)}
+                size="small"
+                type="button"
+              >
+                {isEnabled ? control.onIcon : control.offIcon}
+              </IconButton>
+            </Tooltip>
+            {onSelectDevice != null && (
+              <InputDeviceSelect
+                kind={control.kind}
+                label={control.selectLabel}
+                devices={control.devices}
+                selectedDeviceId={control.selectedDeviceId}
+                disabled={disabled}
+                onSelect={(deviceId) => selectDevice(control.kind, deviceId)}
+              />
+            )}
+          </Box>
+        );
+      })}
     </Stack>
   );
 }

--- a/streamlit_webrtc/frontend/src/InputMediaControls.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.tsx
@@ -18,7 +18,6 @@ type DeviceIds = Partial<Record<InputDeviceKind, MediaDeviceInfo["deviceId"]>>;
 interface InputMediaControlsProps {
   stream: MediaStream;
   disabled?: boolean;
-  selectedDeviceIds: DeviceIds;
   onSelectDevice: (
     kind: InputDeviceKind,
     deviceId: MediaDeviceInfo["deviceId"],
@@ -27,6 +26,20 @@ interface InputMediaControlsProps {
 
 function getTracks(stream: MediaStream, kind: InputDeviceKind) {
   return kind === "video" ? stream.getVideoTracks() : stream.getAudioTracks();
+}
+
+// The device behind the track that is actually feeding the connection. A
+// remembered selection cannot answer this: a track ends when its device is
+// unplugged and stays ended when the same device is plugged back in, ID and
+// all, so an ID that appears in the device list again still names nothing live.
+function getLiveDeviceId(
+  stream: MediaStream,
+  kind: InputDeviceKind,
+): MediaDeviceInfo["deviceId"] | undefined {
+  const track = getTracks(stream, kind).find(
+    (candidate) => candidate.readyState === "live",
+  );
+  return track?.getSettings?.().deviceId;
 }
 
 function areTracksEnabled(stream: MediaStream, kind: InputDeviceKind) {
@@ -160,7 +173,6 @@ function InputDeviceSelect({
 function InputMediaControls({
   disabled = false,
   stream,
-  selectedDeviceIds,
   onSelectDevice,
 }: InputMediaControlsProps) {
   const hasVideo = stream.getVideoTracks().length > 0;
@@ -233,7 +245,8 @@ function InputMediaControls({
       disableLabel: labels.turnCameraOff,
       selectLabel: labels.selectCamera,
       devices: devices.video,
-      selectedDeviceId: pendingDeviceIds.video ?? selectedDeviceIds.video,
+      selectedDeviceId:
+        pendingDeviceIds.video ?? getLiveDeviceId(stream, "video"),
     },
     {
       kind: "audio" as const,
@@ -244,7 +257,8 @@ function InputMediaControls({
       disableLabel: labels.muteMicrophone,
       selectLabel: labels.selectMicrophone,
       devices: devices.audio,
-      selectedDeviceId: pendingDeviceIds.audio ?? selectedDeviceIds.audio,
+      selectedDeviceId:
+        pendingDeviceIds.audio ?? getLiveDeviceId(stream, "audio"),
     },
   ].filter((control) => control.present);
 

--- a/streamlit_webrtc/frontend/src/InputMediaControls.tsx
+++ b/streamlit_webrtc/frontend/src/InputMediaControls.tsx
@@ -89,17 +89,22 @@ function InputDeviceSelect({
   disabled,
   onSelect,
 }: InputDeviceSelectProps) {
-  // Without a second device there is nothing to pick, and without knowing which
-  // device is live the picker would misreport the current one.
   const currentDevice = devices.find(
     (device) => device.deviceId === selectedDeviceId,
   );
-  if (devices.length < 2 || currentDevice == null) {
+  // Only the absence of anything to switch to hides the picker. The live
+  // device going missing does not qualify: an unplugged camera is when the
+  // picker matters most, and where playback is driven by the app rather than
+  // the user it is the only control left to recover through.
+  const hasAlternative = devices.some(
+    (device) => device.deviceId !== selectedDeviceId,
+  );
+  if (!hasAlternative) {
     return null;
   }
 
   return (
-    <Tooltip title={currentDevice.label || label}>
+    <Tooltip title={currentDevice?.label || label}>
       <Box
         sx={{
           position: "relative",
@@ -127,10 +132,20 @@ function InputDeviceSelect({
         <ArrowDropDownIcon fontSize="small" />
         <DeviceSelectOverlay
           aria-label={label}
-          value={currentDevice.deviceId}
+          // Empty once the live device is gone, so the native picker marks
+          // none of the survivors as the one in use.
+          value={currentDevice?.deviceId ?? ""}
           disabled={disabled}
           onChange={(e) => onSelect(e.target.value)}
         >
+          {currentDevice == null && (
+            // Something has to hold the empty value: a select with no option
+            // selected falls back to the first one it can, which would name a
+            // device that is not the one in use.
+            <option value="" disabled>
+              {label}
+            </option>
+          )}
           {devices.map((device, index) => (
             <option key={device.deviceId} value={device.deviceId}>
               {device.label || fallbackDeviceLabel(kind, index)}

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -374,6 +374,54 @@ describe("<WebRtcStreamerInner />", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("ignores a switch that settles after its stream is gone", async () => {
+    stubDevices();
+    let rejectSwitch: ((error: Error) => void) | undefined;
+    const updateInputDevice = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSwitch = reject;
+        }),
+    );
+    const { openAnotherStream } = renderStreamer({ updateInputDevice });
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+
+    // Stopping and starting again replaces the stream the switch was asked
+    // for, so its verdict describes something that no longer exists.
+    await openAnotherStream();
+    await act(async () =>
+      rejectSwitch?.(new DOMException("Device is busy", "NotReadableError")),
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not record a device from a switch whose stream was replaced", async () => {
+    stubDevices();
+    let finishSwitch: (() => void) | undefined;
+    const updateInputDevice = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSwitch = resolve;
+        }),
+    );
+    const { openAnotherStream } = renderStreamer({ updateInputDevice });
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+
+    await openAnotherStream();
+    await act(async () => finishSwitch?.());
+
+    // The switch landed on a track that has since been thrown away; storing
+    // its device would outlive the only stream it was ever true of.
+    expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
   it("preserves both confirmed IDs when video and audio switches overlap", async () => {
     let finishVideoSwitch: (() => void) | undefined;
     let finishAudioSwitch: (() => void) | undefined;

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -465,6 +465,71 @@ describe("<WebRtcStreamerInner />", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("does not report a switch that a later pick for the same kind replaced", async () => {
+    stubDevices();
+    const rejections: Array<(error: Error) => void> = [];
+    const updateInputDevice = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejections.push(reject);
+        }),
+    );
+    renderStreamer({ updateInputDevice });
+    const cameraSelect = await screen.findByRole("combobox", {
+      name: "Select camera",
+    });
+    fireEvent.change(cameraSelect, { target: { value: "other-video" } });
+    fireEvent.change(cameraSelect, { target: { value: "third-video" } });
+
+    // The first pick is no longer what the user is waiting on, and the one
+    // that replaced it can sit on a permission prompt indefinitely.
+    await act(async () =>
+      rejections[0]?.(new DOMException("Device is busy", "NotReadableError")),
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps a camera failure visible when a microphone switch succeeds", async () => {
+    stubDevices();
+    let rejectCamera: ((error: Error) => void) | undefined;
+    let finishMicrophone: (() => void) | undefined;
+    const updateInputDevice = vi.fn(
+      (kind: "video" | "audio") =>
+        new Promise<void>((resolve, reject) => {
+          if (kind === "video") {
+            rejectCamera = reject;
+          } else {
+            finishMicrophone = resolve;
+          }
+        }),
+    );
+    renderStreamer({ updateInputDevice });
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Select microphone" }),
+      { target: { value: "other-audio" } },
+    );
+
+    await act(async () =>
+      rejectCamera?.(new DOMException("Device is busy", "NotReadableError")),
+    );
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Device is busy",
+    );
+
+    // The camera is still on the device it failed to leave, whatever the
+    // microphone went on to do.
+    await act(async () => finishMicrophone?.());
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Device is busy",
+    );
+  });
+
   it("preserves both confirmed IDs when video and audio switches overlap", async () => {
     let finishVideoSwitch: (() => void) | undefined;
     let finishAudioSwitch: (() => void) | undefined;

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -72,8 +72,31 @@ vi.mock("./DeviceSelect/DeviceSelectForm", () => ({
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
   resolvedSelection = { video: "old-video", audio: "old-audio" };
 });
+
+function stubDevices() {
+  const devices = [
+    ["old-video", "videoinput"],
+    ["other-video", "videoinput"],
+    ["old-audio", "audioinput"],
+    ["other-audio", "audioinput"],
+  ].map(([deviceId, kind]) => ({
+    deviceId,
+    groupId: `${deviceId}-group`,
+    kind,
+    label: `${deviceId} label`,
+    toJSON: () => ({}),
+  }));
+  vi.stubGlobal("navigator", {
+    mediaDevices: {
+      enumerateDevices: vi.fn().mockResolvedValue(devices),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+  });
+}
 
 function makeStream() {
   const videoTrack = { enabled: true };
@@ -280,6 +303,47 @@ describe("<WebRtcStreamerInner />", () => {
       await screen.findByRole("button", { name: "Choose another camera" }),
     );
 
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Device is busy",
+    );
+    expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
+  it("switches the input device from the control row while streaming", async () => {
+    stubDevices();
+    const { updateInputDevice } = renderStreamer();
+
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+
+    expect(updateInputDevice).toHaveBeenCalledWith("video", "other-video");
+    await waitFor(() =>
+      expect(persistDeviceIds).toHaveBeenCalledWith(
+        "test-key",
+        { video: "other-video", audio: "old-audio" },
+        { clearing: false },
+      ),
+    );
+  });
+
+  it("shows a failure of a switch made from the control row", async () => {
+    stubDevices();
+    const updateInputDevice = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException("Device is busy", "NotReadableError"),
+      );
+    renderStreamer({ updateInputDevice });
+
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+
+    // The form that reports a switch error is never opened from the control
+    // row, so the failure has to surface in the main view instead.
     expect((await screen.findByRole("alert")).textContent).toContain(
       "Device is busy",
     );

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -91,8 +91,15 @@ function stubDevices() {
 }
 
 function makeStream() {
-  const videoTrack = { enabled: true };
-  const audioTrack = { enabled: true };
+  // The picker reads the device it is showing off the live track, not off the
+  // remembered selection.
+  const makeTrack = (deviceId: string) => ({
+    enabled: true,
+    readyState: "live",
+    getSettings: () => ({ deviceId }),
+  });
+  const videoTrack = makeTrack("old-video");
+  const audioTrack = makeTrack("old-audio");
   return {
     getVideoTracks: () => [videoTrack],
     getAudioTracks: () => [audioTrack],

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -120,10 +120,13 @@ function renderStreamer({
     deviceId: string,
   ) => Promise<void>;
 } = {}) {
-  const mockWebRtc = (inputMediaStream: MediaStream) =>
+  const mockWebRtc = (
+    inputMediaStream: MediaStream,
+    currentState: string = webRtcState,
+  ) =>
     vi.mocked(useWebRtc).mockReturnValue({
       state: {
-        webRtcState,
+        webRtcState: currentState as typeof webRtcState,
         sdpOffer: null,
         iceCandidates: {},
         outputMediaStream: null,
@@ -134,7 +137,8 @@ function renderStreamer({
       stop: vi.fn(),
       updateInputDevice,
     });
-  mockWebRtc(makeStream());
+  const stream = makeStream();
+  mockWebRtc(stream);
 
   const streamer = () => (
     <WebRtcStreamerInner
@@ -164,6 +168,11 @@ function renderStreamer({
     onDevicesUnavailable,
     openAnotherStream: async () => {
       mockWebRtc(makeStream());
+      await act(async () => rerender(streamer()));
+    },
+    // Stopping keeps the stream in state while it tears the connection down.
+    enterStopping: async () => {
+      mockWebRtc(stream, "STOPPING");
       await act(async () => rerender(streamer()));
     },
   };
@@ -427,6 +436,33 @@ describe("<WebRtcStreamerInner />", () => {
     // The switch landed on a track that has since been thrown away; storing
     // its device would outlive the only stream it was ever true of.
     expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
+  it("does not report a switch that fails while the stream is being stopped", async () => {
+    stubDevices();
+    let rejectSwitch: ((error: Error) => void) | undefined;
+    const updateInputDevice = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectSwitch = reject;
+        }),
+    );
+    const { enterStopping } = renderStreamer({ updateInputDevice });
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+
+    // Stopping stops the transceivers straight away, which is what the switch
+    // rejects against, while the stream it was made on is still in state.
+    await enterStopping();
+    await act(async () =>
+      rejectSwitch?.(
+        new DOMException("Sender is stopped", "InvalidStateError"),
+      ),
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("preserves both confirmed IDs when video and audio switches overlap", async () => {

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -11,6 +11,7 @@ import { useEffect } from "react";
 import { WebRtcStreamerInner } from "./WebRtcStreamer";
 import { useWebRtc } from "./webrtc";
 import { persistDeviceIds } from "./device-storage";
+import { makeDevice, stubMediaDevices } from "./media-devices-test-utils";
 
 vi.mock("streamlit-component-lib-react-hooks", () => ({
   useRenderData: vi.fn(),
@@ -77,24 +78,15 @@ afterEach(() => {
 });
 
 function stubDevices() {
-  const devices = [
-    ["old-video", "videoinput"],
-    ["other-video", "videoinput"],
-    ["old-audio", "audioinput"],
-    ["other-audio", "audioinput"],
-  ].map(([deviceId, kind]) => ({
-    deviceId,
-    groupId: `${deviceId}-group`,
-    kind,
-    label: `${deviceId} label`,
-    toJSON: () => ({}),
-  }));
-  vi.stubGlobal("navigator", {
-    mediaDevices: {
-      enumerateDevices: vi.fn().mockResolvedValue(devices),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-    },
+  stubMediaDevices({
+    enumerateDevices: vi
+      .fn()
+      .mockResolvedValue([
+        makeDevice("old-video", "videoinput"),
+        makeDevice("other-video", "videoinput"),
+        makeDevice("old-audio", "audioinput"),
+        makeDevice("other-audio", "audioinput"),
+      ]),
   });
 }
 
@@ -121,21 +113,23 @@ function renderStreamer({
     deviceId: string,
   ) => Promise<void>;
 } = {}) {
-  vi.mocked(useWebRtc).mockReturnValue({
-    state: {
-      webRtcState,
-      sdpOffer: null,
-      iceCandidates: {},
-      outputMediaStream: null,
-      inputMediaStream: makeStream(),
-      error: null,
-    },
-    start: vi.fn(),
-    stop: vi.fn(),
-    updateInputDevice,
-  });
+  const mockWebRtc = (inputMediaStream: MediaStream) =>
+    vi.mocked(useWebRtc).mockReturnValue({
+      state: {
+        webRtcState,
+        sdpOffer: null,
+        iceCandidates: {},
+        outputMediaStream: null,
+        inputMediaStream,
+        error: null,
+      },
+      start: vi.fn(),
+      stop: vi.fn(),
+      updateInputDevice,
+    });
+  mockWebRtc(makeStream());
 
-  render(
+  const streamer = () => (
     <WebRtcStreamerInner
       disabled={false}
       mode="SENDRECV"
@@ -150,13 +144,22 @@ function renderStreamer({
       audioHtmlAttrs={{}}
       mediaToggleControls={mediaToggleControls}
       onComponentValueChange={vi.fn()}
-    />,
+    />
   );
+  const { rerender } = render(streamer());
 
   const [, , , , onDevicesOpened, onDevicesUnavailable] =
     vi.mocked(useWebRtc).mock.calls[0];
 
-  return { updateInputDevice, onDevicesOpened, onDevicesUnavailable };
+  return {
+    updateInputDevice,
+    onDevicesOpened,
+    onDevicesUnavailable,
+    openAnotherStream: async () => {
+      mockWebRtc(makeStream());
+      await act(async () => rerender(streamer()));
+    },
+  };
 }
 
 describe("<WebRtcStreamerInner />", () => {
@@ -348,6 +351,27 @@ describe("<WebRtcStreamerInner />", () => {
       "Device is busy",
     );
     expect(persistDeviceIds).not.toHaveBeenCalled();
+  });
+
+  it("drops a switch error once another stream opens", async () => {
+    stubDevices();
+    const updateInputDevice = vi
+      .fn()
+      .mockRejectedValue(
+        new DOMException("Device is busy", "NotReadableError"),
+      );
+    const { openAnotherStream } = renderStreamer({ updateInputDevice });
+    fireEvent.change(
+      await screen.findByRole("combobox", { name: "Select camera" }),
+      { target: { value: "other-video" } },
+    );
+    await screen.findByRole("alert");
+
+    // The error described the stream it happened on; a restart replaces that
+    // one, and the alert sits above whatever is playing now.
+    await openAnotherStream();
+
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("preserves both confirmed IDs when video and audio switches overlap", async () => {

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.test.tsx
@@ -479,12 +479,16 @@ describe("<WebRtcStreamerInner />", () => {
       name: "Select camera",
     });
     fireEvent.change(cameraSelect, { target: { value: "other-video" } });
-    fireEvent.change(cameraSelect, { target: { value: "third-video" } });
+    fireEvent.change(cameraSelect, { target: { value: "old-video" } });
+    expect(updateInputDevice.mock.calls).toEqual([
+      ["video", "other-video"],
+      ["video", "old-video"],
+    ]);
 
     // The first pick is no longer what the user is waiting on, and the one
     // that replaced it can sit on a permission prompt indefinitely.
     await act(async () =>
-      rejections[0]?.(new DOMException("Device is busy", "NotReadableError")),
+      rejections[0](new DOMException("Device is busy", "NotReadableError")),
     );
 
     expect(screen.queryByRole("alert")).toBeNull();
@@ -513,9 +517,13 @@ describe("<WebRtcStreamerInner />", () => {
       screen.getByRole("combobox", { name: "Select microphone" }),
       { target: { value: "other-audio" } },
     );
+    expect(updateInputDevice.mock.calls).toEqual([
+      ["video", "other-video"],
+      ["audio", "other-audio"],
+    ]);
 
     await act(async () =>
-      rejectCamera?.(new DOMException("Device is busy", "NotReadableError")),
+      rejectCamera!(new DOMException("Device is busy", "NotReadableError")),
     );
     expect((await screen.findByRole("alert")).textContent).toContain(
       "Device is busy",
@@ -523,7 +531,7 @@ describe("<WebRtcStreamerInner />", () => {
 
     // The camera is still on the device it failed to leave, whatever the
     // microphone went on to do.
-    await act(async () => finishMicrophone?.());
+    await act(async () => finishMicrophone!());
 
     expect((await screen.findByRole("alert")).textContent).toContain(
       "Device is busy",

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -315,7 +315,6 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
               <InputMediaControls
                 disabled={buttonDisabled}
                 stream={inputMediaStream}
-                selectedDeviceIds={deviceIds}
                 onSelectDevice={selectInputDevice}
               />
             )}

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -157,8 +157,14 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
     setDeviceSelectOpen(true);
   }, []);
   const closeDeviceSelect = useCallback(() => {
+    setDeviceSwitchError(null);
     setDeviceSelectOpen(false);
   }, []);
+  // A switch error describes the stream it happened on. Opening another one
+  // leaves it stale, and it is displayed above that new stream.
+  useEffect(() => {
+    setDeviceSwitchError(null);
+  }, [inputMediaStream]);
   const reconcileDeviceIds = useCallback(
     (nextDeviceIds: {
       video?: MediaDeviceInfo["deviceId"];

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -139,6 +139,10 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   const receivable = isWebRtcMode(mode) && isReceivable(mode);
   const transmittable = isWebRtcMode(mode) && isTransmittable(mode);
   const inputMediaStream = state.inputMediaStream;
+  // Read by switches in flight, which need the stream that is current when
+  // they settle rather than the one captured when they started.
+  const inputMediaStreamRef = useRef(inputMediaStream);
+  inputMediaStreamRef.current = inputMediaStream;
   const showMediaToggleControls =
     props.mediaToggleControls &&
     transmittable &&
@@ -202,9 +206,18 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
         );
         return;
       }
+      // A switch outlives the stream it started on: `getUserMedia` can sit on
+      // a permission prompt for as long as the user takes, and the stream can
+      // be stopped and started again underneath it. Whatever it reports then
+      // describes a stream that is gone, not the one on screen.
+      const requestedStream = inputMediaStreamRef.current;
+      const isStale = () => inputMediaStreamRef.current !== requestedStream;
       setDeviceSwitchError(null);
       try {
         await updateInputDevice(kind, deviceId);
+        if (isStale()) {
+          return;
+        }
         setSelection((prev) =>
           prev.deviceIds[kind] === deviceId
             ? prev
@@ -217,7 +230,11 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       } catch (error: unknown) {
         const switchError =
           error instanceof Error ? error : new Error(String(error));
-        setDeviceSwitchError(switchError);
+        if (!isStale()) {
+          setDeviceSwitchError(switchError);
+        }
+        // Rejected either way, so the caller that made the request can settle
+        // whatever it was showing while it was in flight.
         throw switchError;
       }
     },

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -32,6 +32,20 @@ import InfoHeader from "./InfoHeader";
 
 const DeviceSelectForm = lazy(() => import("./DeviceSelect/DeviceSelectForm"));
 
+type DeviceSwitchErrors = Partial<Record<InputDeviceKind, Error>>;
+
+function withoutKind(
+  errors: DeviceSwitchErrors,
+  kind: InputDeviceKind,
+): DeviceSwitchErrors {
+  if (errors[kind] == null) {
+    return errors;
+  }
+  const next = { ...errors };
+  delete next[kind];
+  return next;
+}
+
 const BACKEND_VANILLA_ICE_TIMEOUT = 10 * 1000; // `aiortc` runs ICE in the Vanilla manner and its timeout is set to 5 seconds: https://github.com/aiortc/aioice/blob/fc863fde4676e1f67dce981b7f9592ab02c6a09a/src/aioice/ice.py#L881. We set the timeout here to account for network latency and some additional delay.
 
 interface WebRtcStreamerInnerProps {
@@ -156,21 +170,26 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   );
 
   const [deviceSelectOpen, setDeviceSelectOpen] = useState(false);
-  const [deviceSwitchError, setDeviceSwitchError] = useState<Error | null>(
-    null,
-  );
+  // Kept per kind: a camera that failed to switch is still on the wrong device
+  // after a microphone switch succeeds, so one kind's outcome cannot answer for
+  // the other's.
+  const [deviceSwitchErrors, setDeviceSwitchErrors] =
+    useState<DeviceSwitchErrors>({});
+  const deviceSwitchError =
+    deviceSwitchErrors.video ?? deviceSwitchErrors.audio ?? null;
+  const switchRequestIdsRef = useRef({ video: 0, audio: 0 });
   const openDeviceSelect = useCallback(() => {
-    setDeviceSwitchError(null);
+    setDeviceSwitchErrors({});
     setDeviceSelectOpen(true);
   }, []);
   const closeDeviceSelect = useCallback(() => {
-    setDeviceSwitchError(null);
+    setDeviceSwitchErrors({});
     setDeviceSelectOpen(false);
   }, []);
   // A switch error describes the stream it happened on. Opening another one
   // leaves it stale, and it is displayed above that new stream.
   useEffect(() => {
-    setDeviceSwitchError(null);
+    setDeviceSwitchErrors({});
   }, [inputMediaStream]);
   const reconcileDeviceIds = useCallback(
     (nextDeviceIds: {
@@ -215,12 +234,16 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
       // then describes a stream that is gone, not the one on screen. Stopping
       // alone is enough: it stops the transceivers straight away, which is
       // what a switch landing during those moments rejects against, while the
-      // stream it was made on is still the one in state.
+      // stream it was made on is still the one in state. A later pick for the
+      // same kind supersedes this one just as completely, and owns what is
+      // displayed for it.
       const requestedStream = inputMediaStreamRef.current;
+      const requestId = ++switchRequestIdsRef.current[kind];
       const isStale = () =>
+        switchRequestIdsRef.current[kind] !== requestId ||
         inputMediaStreamRef.current !== requestedStream ||
         !isStreamingRef.current;
-      setDeviceSwitchError(null);
+      setDeviceSwitchErrors((prev) => withoutKind(prev, kind));
       try {
         await updateInputDevice(kind, deviceId);
         if (isStale()) {
@@ -234,12 +257,12 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
                 clearing: false,
               },
         );
-        setDeviceSwitchError(null);
+        setDeviceSwitchErrors((prev) => withoutKind(prev, kind));
       } catch (error: unknown) {
         const switchError =
           error instanceof Error ? error : new Error(String(error));
         if (!isStale()) {
-          setDeviceSwitchError(switchError);
+          setDeviceSwitchErrors((prev) => ({ ...prev, [kind]: switchError }));
         }
         // Rejected either way, so the caller that made the request can settle
         // whatever it was showing while it was in flight.

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -139,10 +139,13 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   const receivable = isWebRtcMode(mode) && isReceivable(mode);
   const transmittable = isWebRtcMode(mode) && isTransmittable(mode);
   const inputMediaStream = state.inputMediaStream;
-  // Read by switches in flight, which need the stream that is current when
-  // they settle rather than the one captured when they started.
+  // Read by switches in flight, which need what is current when they settle
+  // rather than what was captured when they started.
   const inputMediaStreamRef = useRef(inputMediaStream);
   inputMediaStreamRef.current = inputMediaStream;
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current =
+    state.webRtcState === "SIGNALLING" || state.webRtcState === "PLAYING";
   const showMediaToggleControls =
     props.mediaToggleControls &&
     transmittable &&
@@ -207,11 +210,16 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
         return;
       }
       // A switch outlives the stream it started on: `getUserMedia` can sit on
-      // a permission prompt for as long as the user takes, and the stream can
-      // be stopped and started again underneath it. Whatever it reports then
-      // describes a stream that is gone, not the one on screen.
+      // a permission prompt for as long as the user takes, and the connection
+      // can be stopped and started again underneath it. Whatever it reports
+      // then describes a stream that is gone, not the one on screen. Stopping
+      // alone is enough: it stops the transceivers straight away, which is
+      // what a switch landing during those moments rejects against, while the
+      // stream it was made on is still the one in state.
       const requestedStream = inputMediaStreamRef.current;
-      const isStale = () => inputMediaStreamRef.current !== requestedStream;
+      const isStale = () =>
+        inputMediaStreamRef.current !== requestedStream ||
+        !isStreamingRef.current;
       setDeviceSwitchError(null);
       try {
         await updateInputDevice(kind, deviceId);

--- a/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
+++ b/streamlit_webrtc/frontend/src/WebRtcStreamer.tsx
@@ -238,7 +238,9 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
   return (
     <Box>
       <InfoHeader
-        error={state.error}
+        // A switch started from the controls below has no form to report into,
+        // so its failure surfaces here.
+        error={state.error ?? deviceSwitchError}
         shouldShowTakingTooLongWarning={
           state.webRtcState === "SIGNALLING" && isTakingTooLong
         }
@@ -290,6 +292,8 @@ export function WebRtcStreamerInner(props: WebRtcStreamerInnerProps) {
               <InputMediaControls
                 disabled={buttonDisabled}
                 stream={inputMediaStream}
+                selectedDeviceIds={deviceIds}
+                onSelectDevice={selectInputDevice}
               />
             )}
           </Box>

--- a/streamlit_webrtc/frontend/src/translation/TranslationProvider.tsx
+++ b/streamlit_webrtc/frontend/src/translation/TranslationProvider.tsx
@@ -20,6 +20,8 @@ function TranslationProvider(props: TranslationProviderProps) {
     turn_camera_off,
     mute_microphone,
     unmute_microphone,
+    select_camera,
+    select_microphone,
   } = renderData.args["translations"] || {};
   const value: Translations = useMemo(
     () => ({
@@ -34,6 +36,8 @@ function TranslationProvider(props: TranslationProviderProps) {
       turn_camera_off,
       mute_microphone,
       unmute_microphone,
+      select_camera,
+      select_microphone,
     }),
     [
       start,
@@ -47,6 +51,8 @@ function TranslationProvider(props: TranslationProviderProps) {
       turn_camera_off,
       mute_microphone,
       unmute_microphone,
+      select_camera,
+      select_microphone,
     ],
   );
   return (

--- a/streamlit_webrtc/frontend/src/translation/types.ts
+++ b/streamlit_webrtc/frontend/src/translation/types.ts
@@ -10,5 +10,7 @@ export interface Translations {
   turn_camera_off: string | null;
   mute_microphone: string | null;
   unmute_microphone: string | null;
+  select_camera: string | null;
+  select_microphone: string | null;
 }
 export type TranslationKey = keyof Translations;

--- a/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
+++ b/streamlit_webrtc/frontend/src/webrtc/index.test.tsx
@@ -1,36 +1,138 @@
-import { cleanup, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWebRtc } from ".";
+
+const switchInputDevice = vi.fn<() => Promise<void>>();
+vi.mock("./switch-input-device", () => ({
+  switchInputDevice: () => switchInputDevice(),
+}));
+vi.mock("webrtc-adapter", () => ({ default: {} }));
+
+function makeStream(name: string): MediaStream {
+  const track = {
+    kind: "video",
+    enabled: true,
+    readyState: "live",
+    stop: vi.fn(),
+    getSettings: () => ({ deviceId: name }),
+  };
+  return {
+    name,
+    getTracks: () => [track],
+    getVideoTracks: () => [track],
+    getAudioTracks: () => [],
+  } as unknown as MediaStream;
+}
+
+class FakePeerConnection {
+  localDescription = { type: "offer", sdp: "sdp", toJSON: () => ({}) };
+  connectionState = "new";
+  private senders: Array<{ track: unknown }> = [];
+  addEventListener() {}
+  addTrack(track: unknown) {
+    this.senders.push({ track });
+  }
+  addTransceiver() {}
+  getTransceivers() {
+    return [];
+  }
+  getSenders() {
+    return this.senders;
+  }
+  createOffer() {
+    return Promise.resolve(this.localDescription);
+  }
+  setLocalDescription() {
+    return Promise.resolve();
+  }
+  close() {}
+}
+
+function renderWebRtc() {
+  return renderHook(() =>
+    useWebRtc(
+      {
+        mode: "SENDONLY",
+        desiredPlayingState: undefined,
+        sdpAnswerJson: undefined,
+        rtcConfiguration: undefined,
+        mediaStreamConstraints: { video: true, audio: false },
+        sendbackVideo: false,
+        sendbackAudio: false,
+      },
+      undefined,
+      undefined,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+    ),
+  );
+}
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.resetAllMocks();
 });
 
 describe("useWebRtc", () => {
   it("rejects device switching without an active input stream", async () => {
-    const { result } = renderHook(() =>
-      useWebRtc(
-        {
-          mode: "SENDRECV",
-          desiredPlayingState: undefined,
-          sdpAnswerJson: undefined,
-          rtcConfiguration: undefined,
-          mediaStreamConstraints: { video: true, audio: true },
-          sendbackVideo: true,
-          sendbackAudio: true,
-        },
-        undefined,
-        undefined,
-        vi.fn(),
-        vi.fn(),
-        vi.fn(),
-      ),
-    );
+    const { result } = renderWebRtc();
 
     await expect(
       result.current.updateInputDevice("video", "next-video"),
     ).rejects.toThrow(
       "Cannot switch input device without an active WebRTC input stream",
     );
+  });
+
+  describe("when a switch outlives the stream it was made against", () => {
+    const getUserMedia = vi.fn<() => Promise<MediaStream>>();
+
+    beforeEach(() => {
+      vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+      vi.stubGlobal("RTCPeerConnection", FakePeerConnection);
+    });
+
+    it("leaves the stream that replaced it in place", async () => {
+      const first = makeStream("first");
+      const second = makeStream("second");
+      getUserMedia.mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+      let finishSwitch: (() => void) | undefined;
+      switchInputDevice.mockReturnValue(
+        new Promise<void>((resolve) => {
+          finishSwitch = resolve;
+        }),
+      );
+
+      const { result } = renderWebRtc();
+      await act(async () => result.current.start());
+      expect(result.current.state.inputMediaStream).toBe(first);
+
+      const switching = result.current
+        .updateInputDevice("video", "next-video")
+        .catch(() => undefined);
+
+      // `getUserMedia` can sit on a permission prompt long enough for the
+      // connection to be stopped and started again underneath the switch.
+      vi.useFakeTimers();
+      await act(async () => {
+        result.current.stop();
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      vi.useRealTimers();
+      await act(async () => result.current.start());
+      expect(result.current.state.inputMediaStream).toBe(second);
+
+      await act(async () => {
+        finishSwitch?.();
+        await switching;
+      });
+
+      // Publishing the stream the switch was made against would put a stopped
+      // one back in place of the one now playing.
+      expect(result.current.state.inputMediaStream).toBe(second);
+    });
   });
 });

--- a/streamlit_webrtc/frontend/src/webrtc/index.ts
+++ b/streamlit_webrtc/frontend/src/webrtc/index.ts
@@ -100,27 +100,41 @@ export const useWebRtc = (
   const stopRef = useRef(stop);
   stopRef.current = stop;
 
+  const inputMediaStreamRef = useRef(state.inputMediaStream);
+  inputMediaStreamRef.current = state.inputMediaStream;
+
   const updateInputDevice = useCallback(
     async (
       kind: InputDeviceKind,
       deviceId: MediaDeviceInfo["deviceId"],
     ): Promise<void> => {
       const pc = pcRef.current;
-      if (pc == null || state.inputMediaStream == null) {
+      const inputMediaStream = state.inputMediaStream;
+      if (pc == null || inputMediaStream == null) {
         throw new Error(
           "Cannot switch input device without an active WebRTC input stream",
         );
       }
       await switchInputDevice(
         pc,
-        state.inputMediaStream,
+        inputMediaStream,
         props.mediaStreamConstraints,
         kind,
         deviceId,
       );
+      // `getUserMedia` can sit on a permission prompt for as long as the user
+      // takes, long enough for the connection to be stopped and started again.
+      // Publishing the stream this switch was made against would then put a
+      // stopped one back in place of the one now playing.
+      if (
+        pcRef.current !== pc ||
+        inputMediaStreamRef.current !== inputMediaStream
+      ) {
+        return;
+      }
       dispatch({
         type: "SET_INPUT_MEDIA_STREAM",
-        inputMediaStream: state.inputMediaStream,
+        inputMediaStream,
       });
     },
     [props.mediaStreamConstraints, state.inputMediaStream],


### PR DESCRIPTION
Switching a camera or microphone mid-stream was only reachable through the device selector, which replaces the whole component with a form: the stream disappears from view and the user has to press Done to get back. The toggles under the stream are where the user already goes to control their camera and microphone.

Each toggle now carries an arrow that lists the devices of that kind and switches to the one picked, through `selectInputDevice`, the same path the selector form uses, so the switch, the stored choice and the error handling stay in one place. The two toggles are built from one per-kind list so each can carry its own picker. An arrow appears whenever the browser reports another device of that kind to switch to, including when the device in use has been unplugged, which is when it matters most: where playback is driven by `desired_playing_state` there is no Start, Stop or Select Device button to recover through. It is disabled while its kind is toggled off, since switching opens the chosen device and would light the indicator of a camera the screen shows as off.

The picker is a transparent native `<select>` over the arrow rather than a rendered menu, because Streamlit pins the component iframe's height to its content and a menu drawn in the document would be clipped by the frame, while a native dropdown is drawn by the browser outside it and opens as a native picker on mobile.

A switch started here has no form to report a failure into, so the error surfaces above the stream instead. It is cleared when the form is closed or another stream opens, and a switch that settles after its own stream is gone is dropped rather than reported against the replacement, since `getUserMedia` can sit on a permission prompt for long enough to outlive a stop and restart.

The dropdown labels are translatable through the new `select_camera` and `select_microphone` entries of `translations`.

`pnpm test` in `streamlit_webrtc/frontend` runs the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added camera and microphone dropdowns to streaming controls for switching input devices.
  * Dropdowns appear when alternative devices are available and reflect the active selection.
  * Added customizable camera and microphone labels, including Japanese translations.

* **Bug Fixes**
  * Improved feedback and recovery when switching devices, unplugging hardware, or changing streams.
  * Prevented outdated device-switch requests from replacing newer active streams.
  * Disabled device selectors when media controls are unavailable or turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->